### PR TITLE
Fix data-forge warning in flint/Outputs.vue

### DIFF
--- a/flint.ui/src/views/flint/Outputs.vue
+++ b/flint.ui/src/views/flint/Outputs.vue
@@ -22,8 +22,7 @@
 </template>
 
 <script>
-import dataForge from 'data-forge'
-// const dataForge = require("data-forge");
+import { fromCSV } from 'data-forge'
 
 export default {
   name: 'BrushCharts',
@@ -157,7 +156,7 @@ export default {
       lines.splice(0, 4)
       lines.splice(-4)
       dataset = lines.join('\n')
-      const df = dataForge.fromCSV(dataset)
+      const df = fromCSV(dataset)
       let df_as_array = df.toArray()
       console.log(typeof df_as_array)
       console.log('array1')


### PR DESCRIPTION
This resolves a small warning resulting from how data-forge modules were imported.

```
warning  in ./src/views/flint/Outputs.vue?vue&type=script&lang=js&
"export 'default' (imported as 'dataForge') was not found in 'data-forge'
```

### Before:

```
import dataForge from 'data-forge'
```

### Now:

```
import { fromCSV } from 'data-forge'
```