### PR TITLE
Temporarily halting storybook in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
       - ./flint.ui:/usr/src/app/flint.ui
       - ./flint.cloud/local/rest_api_flint.example/output:/server/output
       - /usr/src/app/flint.ui/node_modules
-  storybook:
-    container_name: storybook
-    ports:
-      - "6006:6006"
-    build:
-      context: ./flint.ui
-      dockerfile: ./.storybook/Dockerfile
+  # storybook:
+  #   container_name: storybook
+  #   ports:
+  #     - "6006:6006"
+  #   build:
+  #     context: ./flint.ui
+  #     dockerfile: ./.storybook/Dockerfile


### PR DESCRIPTION
## Description

As per #48, Storybook is not working as intended and takes up significant amount of time to build in `docker-compose`. We may come later after updating all the components. 

## Testing

Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! --->
