### PR TITLE
add feature: create new GCBM job!

### DIFF
--- a/flint.ui/src/store/modules/gcbm.js
+++ b/flint.ui/src/store/modules/gcbm.js
@@ -1,8 +1,9 @@
 //import Vue from 'vue'
-//import axios from 'axios'
+import axios from 'axios'
 
 export default {
   state: {
+    title: '',
     pools_cbm: {
       Pools: {
         AboveGroundFastSoil: 0.0,
@@ -632,7 +633,37 @@ export default {
       }
     }
   },
-  mutations: {},
+  mutations: {
+    save_new_gcbm_job_title(state, title) {
+      console.log('passed title')
+      console.log(title)
+      state.title = title
+      console.log(state.title)
+    }
+  },
 
-  actions: {}
+  actions: {
+    title_setter({ commit }, payload) {
+      commit('save_new_gcbm_job_title', payload)
+      console.log('from title_setter')
+      console.log(this.state.gcbm.title)
+      //dispatch(this.send_new_gcbm_job_title)
+    },
+    send_new_gcbm_job_title() {
+      var bodyFormData = new FormData()
+      console.log(this.state.gcbm.title)
+      bodyFormData.append('title', this.state.gcbm.title)
+      console.log([...bodyFormData])
+      axios
+        .post('http://127.0.0.1:8081/gcbm/new', bodyFormData)
+        .then((response) => {
+          this._vm.$toast.success(`${response}`, { timeout: 2000 })
+          console.log(response)
+        })
+        .catch((error) => {
+          this._vm.$toast.error(`${error}`, { timeout: 2000 })
+          console.log(error)
+        })
+    }
+  }
 }

--- a/flint.ui/src/views/gcbm/GCBMDashboard.vue
+++ b/flint.ui/src/views/gcbm/GCBMDashboard.vue
@@ -276,7 +276,31 @@
                         :class="{ 'opacity-25 cursor-not-allowed': isTitle() }"
                         @click="setNewTitle"
                       >
-                        <i class="fas fa-plus" /> New
+                        <i class="fas fa-plus" /> Set title
+                      </button>
+
+                      <button
+                        class="
+                          w-full
+                          mt-4
+                          block
+                          align-middle
+                          flex-initial
+                          bg-white
+                          hover:bg-black hover:text-white
+                          text-gray-800
+                          font-semibold
+                          py-2
+                          px-4
+                          border border-gray-400
+                          rounded
+                          shadow
+                        "
+                        :disabled="isTitle()"
+                        :class="{ 'opacity-25 cursor-not-allowed': isTitle() }"
+                        @click="sendToAPI"
+                      >
+                        <i class="fas fa-plus" /> Create run
                       </button>
                     </div>
                     <p class="text-sm text-blueGray-400 mt-4">
@@ -336,6 +360,17 @@ export default {
     setNewTitle() {
       //function for setting up a new title
       console.log(this.simulation_title, ' goto /gcbm/new')
+      var simulation_title = this.simulation_title
+      console.log('simulation_title')
+      console.log(simulation_title)
+
+      this.$store.dispatch('title_setter', simulation_title)
+      console.log('from set new title')
+      console.log(this.gcbm.state.Title)
+    },
+    sendToAPI() {
+      //function to send the title to API
+      this.$store.dispatch('send_new_gcbm_job_title')
     }
   }
 }


### PR DESCRIPTION
## Description

Add feature: Create new GCBM job with a custom Title!

![image](https://user-images.githubusercontent.com/13800316/129482162-53951900-e2c7-4c14-8b43-7ca8b13aabaf.png)

In this image `yoyo` is a custom title for the GCBM job!
This list can be obtained by making a GET request to http://127.0.0.1:8081/gcbm/list

`Set title` button store the job title in the state, while `Create run` sends the POST request to the API. 
