### PR TITLE
Using moment.js to get the difference b/w start and end dates in Datepicker component

### DIFF
--- a/flint.ui/src/components/Datepicker/DatepickerPoint.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerPoint.vue
@@ -5,12 +5,35 @@
 
     <md-button class="md-primary">End Date</md-button>
     <md-datepicker v-model="selectedendDate" :md-model-type="String" />
+
+    <h3 class="text-xl font-bold mb-2 text-gray-600 justify-center">
+      Simulation length is
+      <span class="text-red-600">{{
+        date_diff > 0 ? date_diff.toFixed(2) + ' years' : 'invalid'
+      }}</span>
+    </h3>
   </div>
 </template>
 
 <script>
+import moment from 'moment'
+
 export default {
   computed: {
+    date_diff() {
+      let start_date =
+        this.$store.state.point.config.LocalDomain.start_date.split('/')
+      console.log(start_date)
+      let end_date =
+        this.$store.state.point.config.LocalDomain.end_date.split('/')
+      console.log(end_date)
+      //moment requires months to be zero indexed, hence subtracting 1
+      let start_year_month = moment([+start_date[0], +start_date[1] - 1])
+      let end_year_month = moment([+end_date[0], +end_date[1] - 1])
+
+      let date_difference = end_year_month.diff(start_year_month, 'years', true)
+      return date_difference
+    },
     selectedstartDate: {
       get() {
         return this.$store.state.point.config.LocalDomain.start_date
@@ -22,6 +45,12 @@ export default {
           'setNew_point_startDate',
           newValue.split('-').join('/')
         )
+
+        if (this.date_diff < 0) {
+          this.$toast.error('Start date should be less than end date', {
+            timeout: 5000
+          })
+        }
       }
     },
 
@@ -36,6 +65,12 @@ export default {
           'setNew_point_endDate',
           newValue.split('-').join('/')
         )
+
+        if (this.date_diff < 0) {
+          this.$toast.error('End date should be greater than start date', {
+            timeout: 5000
+          })
+        }
       }
     }
   }

--- a/flint.ui/src/components/Datepicker/DatepickerRothC.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerRothC.vue
@@ -5,12 +5,35 @@
 
     <md-button class="md-primary">End Date</md-button>
     <md-datepicker v-model="selectedendDate" :md-model-type="String" />
+
+    <h3 class="text-xl font-bold mb-2 text-gray-600 justify-center">
+      Simulation length is
+      <span class="text-red-600">{{
+        date_diff > 0 ? date_diff.toFixed(2) + ' years' : 'invalid'
+      }}</span>
+    </h3>
   </div>
 </template>
 
 <script>
+import moment from 'moment'
+
 export default {
   computed: {
+    date_diff() {
+      let start_date =
+        this.$store.state.rothc.config.LocalDomain.start_date.split('/')
+      console.log(start_date)
+      let end_date =
+        this.$store.state.rothc.config.LocalDomain.end_date.split('/')
+      console.log(end_date)
+      //moment requires months to be zero indexed, hence subtracting 1
+      let start_year_month = moment([+start_date[0], +start_date[1] - 1])
+      let end_year_month = moment([+end_date[0], +end_date[1] - 1])
+
+      let date_difference = end_year_month.diff(start_year_month, 'years', true)
+      return date_difference
+    },
     selectedstartDate: {
       get() {
         return this.$store.state.rothc.config.LocalDomain.start_date
@@ -22,6 +45,12 @@ export default {
           'setNew_rothc_startDate',
           newValue.split('-').join('/')
         )
+
+        if (this.date_diff < 0) {
+          this.$toast.error('Start date should be less than end date', {
+            timeout: 5000
+          })
+        }
       }
     },
 
@@ -36,6 +65,12 @@ export default {
           'setNew_rothc_endDate',
           newValue.split('-').join('/')
         )
+
+        if (this.date_diff < 0) {
+          this.$toast.error('End date should be greater than start date', {
+            timeout: 5000
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

#57 added `moment.js` lib to calculate time difference between simulation runs. Here's the preview for the same - 

https://user-images.githubusercontent.com/58583793/129698307-0d75944f-340c-433a-aa16-40a39ae133f1.mov



## Testing

Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! --->
