### PR TITLE
fix: Refactor text color and content of landing page

### DIFF
--- a/flint.ui/src/views/Landing.vue
+++ b/flint.ui/src/views/Landing.vue
@@ -30,11 +30,11 @@
               <h1 class="text-white font-semibold text-5xl">
                 About the FLINT UI.
               </h1>
-              <p class="mt-4 text-lg text-blueGray-200">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit.
-                Repellendus consectetur vero molestias ab doloremque quia id
-                debitis nemo illum expedita. Quia cumque aut ipsam id dolores
-                est temporibus fugit blanditiis.
+              <p class="mt-4 text-lg text-white">
+               This project provides an intuitive way for new to explore some preconfigured FLINT modules,
+               including the Generic Budget Carbon Model (GCBM), in order to better understand how the FLINT
+               system works. Our client is written as a Web application and can be used in a local or remote
+               environment.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Issue

Currently, the landing page of FLINT UI has black text color with example content.

![Screenshot 2021-08-21 at 5 19 43 AM](https://user-images.githubusercontent.com/42106787/130303748-704d02a2-8b1d-447b-a3e9-e2df18e20d4e.jpg)

## Fix

![Screenshot 2021-08-21 at 6 57 41 AM](https://user-images.githubusercontent.com/42106787/130306231-0f059e40-cb17-43ee-86b4-9353b3320898.jpg)
