### PR TITLE
Auto downloading simulation on toggle / Removing console.log statements on production build

### DIFF
--- a/flint.ui/.babelrc
+++ b/flint.ui/.babelrc
@@ -1,0 +1,7 @@
+{
+    "env": {
+        "production": {
+        "plugins": ["transform-remove-console"]
+        }
+    }
+}

--- a/flint.ui/package-lock.json
+++ b/flint.ui/package-lock.json
@@ -36858,6 +36858,11 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
+    },
     "babel-walk": {
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",

--- a/flint.ui/package.json
+++ b/flint.ui/package.json
@@ -22,6 +22,7 @@
     "@vueform/slider": "^2.0.4",
     "apexcharts": "^3.27.3",
     "axios": "^0.21.1",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "core-js": "^3.16.0",
     "data-forge": "^1.8.17",
     "fs": "0.0.1-security",

--- a/flint.ui/src/components/Sidebar/Sidebar.vue
+++ b/flint.ui/src/components/Sidebar/Sidebar.vue
@@ -303,54 +303,6 @@
               </a>
             </router-link>
           </li>
-
-          <li class="items-center">
-            <router-link
-              v-slot="{ href, navigate, isActive }"
-              to="/gcbm/configurations"
-            >
-              <a
-                :href="href"
-                class="text-xs uppercase py-3 font-bold block"
-                :class="[
-                  isActive
-                    ? 'text-emerald-500 hover:text-emerald-600'
-                    : 'text-blueGray-700 hover:text-blueGray-500'
-                ]"
-                @click="navigate"
-              >
-                <i
-                  class="fas fa-cogs mr-2 text-sm"
-                  :class="[isActive ? 'opacity-75' : 'text-blueGray-300']"
-                />
-                Configurations
-              </a>
-            </router-link>
-          </li>
-
-          <li class="items-center">
-            <router-link
-              v-slot="{ href, navigate, isActive }"
-              to="/gcbm/outputs"
-            >
-              <a
-                :href="href"
-                class="text-xs uppercase py-3 font-bold block"
-                :class="[
-                  isActive
-                    ? 'text-emerald-500 hover:text-emerald-600'
-                    : 'text-blueGray-700 hover:text-blueGray-500'
-                ]"
-                @click="navigate"
-              >
-                <i
-                  class="fas fa-layer-group mr-2 text-sm"
-                  :class="[isActive ? 'opacity-75' : 'text-blueGray-300']"
-                />
-                Outputs
-              </a>
-            </router-link>
-          </li>
         </ul>
       </div>
     </div>

--- a/flint.ui/src/components/Sliders/Toggle.vue
+++ b/flint.ui/src/components/Sliders/Toggle.vue
@@ -1,0 +1,74 @@
+<template>
+  <div
+    class="w-min mt-3"
+    @click="
+      toggleActive = !toggleActive
+      checkforAutoProgress()
+    "
+  >
+    <div
+      id="revert-toggle"
+      class="
+        w-10
+        h-6
+        items-center
+        bg-red-600
+        rounded-full
+        p-1
+        duration-300
+        ease-in-out
+        -mx-0
+      "
+      :class="{ 'bg-green-400': toggleActive }"
+    >
+      <div
+        class="
+          bg-white
+          w-4
+          h-4
+          rounded-full
+          shadow-md
+          transform
+          duration-300
+          ease-in-out
+        "
+        :class="{ 'translate-x-4': toggleActive }"
+      ></div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      toggleActive: false,
+      isDownloaded: false
+    }
+  },
+  methods: {
+    checkforAutoProgress() {
+      this.isDownloaded = false
+      console.log('Current state of the switch: ', this.toggleActive)
+      if (this.toggleActive == true) {
+        console.log('toggled = true')
+        this.interval = setInterval(() => {
+          this.$emit('checkstatus')
+
+          if (
+            this.$store.state.gcbm.SimulationProgress ==
+            'Output is ready to download at gcbm/download'
+          ) {
+            console.log('download now')
+            this.$emit('downloadsim')
+            this.isDownloaded = true
+            document.getElementById('revert-toggle').click()
+          }
+        }, 30000)
+      } else {
+        clearInterval(this.interval)
+      }
+    }
+  }
+}
+</script>

--- a/flint.ui/src/components/Sliders/Toggle.vue
+++ b/flint.ui/src/components/Sliders/Toggle.vue
@@ -21,6 +21,9 @@
       "
       :class="{ 'bg-green-400': toggleActive }"
     >
+      <md-tooltip
+        >Toggle to check status and auto-download the simulation</md-tooltip
+      >
       <div
         class="
           bg-white

--- a/flint.ui/src/components/Stepper/StepperGCBM.vue
+++ b/flint.ui/src/components/Stepper/StepperGCBM.vue
@@ -5,9 +5,11 @@
 
       <md-step id="second" to="/gcbm/upload" md-label="Upload dataset" />
 
-      <md-step id="third" to="/gcbm/run" md-label="Run" />
-
-      <md-step id="fourth" md-label="Download" />
+      <md-step
+        id="third"
+        to="/gcbm/run"
+        md-label="Run | Check status | Download"
+      />
     </md-steppers>
   </div>
 </template>

--- a/flint.ui/src/routes/routes.js
+++ b/flint.ui/src/routes/routes.js
@@ -21,7 +21,6 @@ import RothCOutput from '@/views/flint/RothCOutput.vue'
 import GCBMDashboard from '@/views/gcbm/GCBMDashboard.vue'
 import GCBMUpload from '@/views/gcbm/GCBMUpload.vue'
 import GCBMRun from '@/views/gcbm/GCBMRun.vue'
-import GCBMOutputs from '@/views/gcbm/GCBMOutputs.vue'
 
 import Landing from '@/views/Landing.vue'
 
@@ -109,10 +108,6 @@ const routes = [
       {
         path: '/gcbm/run',
         component: GCBMRun
-      },
-      {
-        path: '/gcbm/outputs',
-        component: GCBMOutputs
       }
     ]
   },

--- a/flint.ui/src/store/modules/gcbm.js
+++ b/flint.ui/src/store/modules/gcbm.js
@@ -634,7 +634,8 @@ export default {
         }
       }
     },
-    DropdownSelectedSim: ''
+    DropdownSelectedSim: '',
+    SimulationProgress: ''
   },
   mutations: {
     setDropdownSimState(state, newValue) {
@@ -645,6 +646,10 @@ export default {
       console.log(title)
       state.config.title = title
       console.log(state.config.title)
+    },
+
+    setSimulationProgressState(state, newValue) {
+      this.state.gcbm.SimulationProgress = newValue
     }
   },
 

--- a/flint.ui/src/store/modules/point.js
+++ b/flint.ui/src/store/modules/point.js
@@ -228,7 +228,6 @@ export default {
             timeout: 2000
           })
           console.log(response)
-          //this.state.received_data = response.data;
           commit('save_point_results', response.data)
           console.log(this.state.point.point_results)
         })

--- a/flint.ui/src/stories/Button.stories.js
+++ b/flint.ui/src/stories/Button.stories.js
@@ -1,39 +1,39 @@
-import MyButton from './Button.vue';
+import MyButton from './Button.vue'
 
 export default {
   title: 'Example/Button',
   component: MyButton,
   argTypes: {
     backgroundColor: { control: 'color' },
-    size: { control: { type: 'select', options: ['small', 'medium', 'large'] } },
-  },
-};
+    size: { control: { type: 'select', options: ['small', 'medium', 'large'] } }
+  }
+}
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { MyButton },
-  template: '<my-button @onClick="onClick" v-bind="$props" />',
-});
+  template: '<my-button @onClick="onClick" v-bind="$props" />'
+})
 
-export const Primary = Template.bind({});
+export const Primary = Template.bind({})
 Primary.args = {
   primary: true,
-  label: 'Button',
-};
+  label: 'Button'
+}
 
-export const Secondary = Template.bind({});
+export const Secondary = Template.bind({})
 Secondary.args = {
-  label: 'Button',
-};
+  label: 'Button'
+}
 
-export const Large = Template.bind({});
+export const Large = Template.bind({})
 Large.args = {
   size: 'large',
-  label: 'Button',
-};
+  label: 'Button'
+}
 
-export const Small = Template.bind({});
+export const Small = Template.bind({})
 Small.args = {
   size: 'small',
-  label: 'Button',
-};
+  label: 'Button'
+}

--- a/flint.ui/src/stories/Button.vue
+++ b/flint.ui/src/stories/Button.vue
@@ -1,5 +1,5 @@
 <template>
-  <button type="button" :class="classes" @click="onClick" :style="style">
+  <button type="button" :class="classes" :style="style" @click="onClick">
     {{ label }}
   </button>
 </template>
@@ -8,7 +8,7 @@
 import './button.css'
 
 export default {
-  name: 'my-button',
+  name: 'MyButton',
 
   props: {
     label: {

--- a/flint.ui/src/views/gcbm/GCBMDashboard.vue
+++ b/flint.ui/src/views/gcbm/GCBMDashboard.vue
@@ -28,9 +28,8 @@
           <div class="flex flex-col mt-4">
             <StepperStatic />
 
-            <div class="flex flex-wrap my-5">
-              <div class="w-full lg:w-6/12 xl:w-4/12 px-4 content-center" />
-              <div class="w-full lg:w-6/12 xl:w-4/12 px-4 content-center">
+            <div class="w-full mt-6">
+              <div class="w-4/12 px-4 mx-auto content-center">
                 <div
                   class="
                     relative
@@ -97,17 +96,8 @@
                         >Creates a new simulation run</span
                       >
                     </p>
-                    <button @click="check_status">
-                      Check for running simulations in console by clicking here
-                    </button>
                   </div>
                 </div>
-              </div>
-
-              <div class="w-full lg:w-6/12 xl:w-4/12 px-4 content-center">
-                <!--
-
-                <FileUpload /> -->
               </div>
             </div>
           </div>
@@ -123,14 +113,11 @@
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 
-// import FileUpload from '@/components/FileUpload/FileUpload.vue'
-
 export default {
   name: 'DashboardPage',
   components: {
     StepperGCBM,
     StepperStatic
-    // FileUpload
   },
 
   data: () => ({

--- a/flint.ui/src/views/gcbm/GCBMRun.vue
+++ b/flint.ui/src/views/gcbm/GCBMRun.vue
@@ -17,30 +17,24 @@
       >
         <div class="px-4 md:px-10 mx-auto w-full">
           <div class="bg-white p-6 rounded-lg shadow-lg">
-            <h2 class="text-2xl font-bold mb-2 text-gray-800">
-              GCBM simulation workflow
-            </h2>
-            <p class="text-gray-700">
-              Follow the steps below to simulate GCBM runs.
-            </p>
+            <div>
+              <h2 class="text-2xl font-bold mb-2 text-gray-800">
+                GCBM simulation workflow
+              </h2>
+              <p class="text-gray-700">
+                Follow the steps below to simulate GCBM runs. Click the toggle
+                to auto download the simulation once complete.
+              </p>
+            </div>
+
+            <Toggle @downloadsim="downloadSim" @checkstatus="checkStatus" />
           </div>
 
           <div class="flex flex-col mt-4">
             <StepperStatic />
 
-            <div class="flex justify-center flex-wrap my-5">
-              <div class="w-full lg:w-6/12 xl:w-2/12 px-4 content-center" />
-              <div
-                class="
-                  flex
-                  w-full
-                  lg:w-6/12
-                  xl:w-8/12
-                  px-4
-                  content-center
-                  justify-center
-                "
-              >
+            <div class="w-full my-5">
+              <div class="w-8/12 px-4 mx-auto content-center justify-center">
                 <div
                   class="
                     relative
@@ -136,8 +130,6 @@
                   </div>
                 </div>
               </div>
-
-              <div class="w-full lg:w-6/12 xl:w-2/12 px-4 content-center" />
             </div>
           </div>
         </div>
@@ -151,32 +143,26 @@
 <script>
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
+import Toggle from '@/components/Sliders/Toggle.vue'
 import axios from 'axios'
 
 export default {
   name: 'DashboardPage',
   components: {
     StepperGCBM,
-    StepperStatic
+    StepperStatic,
+    Toggle
   },
 
   data: () => ({
-    // formData: new FormData(),
     simulation_title: ''
   }),
 
   methods: {
-    // add_title_to_formdata: function () {
-    //   this.formData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
-    //   console.log([...this.formData])
-    // },
     runSim: function () {
-      // var bodyFormData = new FormData()
-      // this.add_title_to_formdata()
       var bodyFormData = new FormData()
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
-      // bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
 
       axios
@@ -192,19 +178,21 @@ export default {
     },
 
     checkStatus: function () {
-      // var bodyFormData = new FormData()
-      // this.add_title_to_formdata()
       var bodyFormData = new FormData()
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
-      // bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
 
       axios
         .post('http://127.0.0.1:8081/gcbm/status', bodyFormData)
         .then((response) => {
-          this.$toast.success(`${response.data.finished}`, { timeout: 5000 })
+          this.$toast.info(`${response.data.finished}`, { timeout: 5000 })
+          this.$store.commit(
+            'setSimulationProgressState',
+            response.data.finished
+          )
           console.log(response)
+          console.log(this.$store.state.gcbm.SimulationProgress)
         })
         .catch((error) => {
           this.$toast.error(`${error}`, { timeout: 2000 })
@@ -213,36 +201,28 @@ export default {
     },
 
     downloadSim: function () {
-      // var bodyFormData = new FormData()
-      // this.add_title_to_formdata()
       var bodyFormData = new FormData()
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
-      // bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
 
       axios
         .post('http://127.0.0.1:8081/gcbm/download', bodyFormData, {
           responseType: 'arraybuffer'
         })
-        // .then((response) => {
-        //   this.$toast.success(`${response}`, { timeout: 5000 })
-        //   console.log(response)
-        // })
-        // .catch((error) => {
-        //   this.$toast.error(`${error}`, { timeout: 2000 })
-        //   console.log(error)
-        // })
-
         .then((response) => {
-          this.$toast.success(`${response}`, { timeout: 5000 })
           console.log(response)
           let blob = new Blob([response.data], { type: 'application/zip' })
           const url = window.URL.createObjectURL(blob)
           console.log(response.data)
           const link = document.createElement('a')
           link.href = url
-          link.setAttribute('download', 'gcbm_run_ouput.zip')
+          link.setAttribute(
+            'download',
+            this.$store.state.gcbm.DropdownSelectedSim +
+              '_gcbm_run_ouput' +
+              '.zip'
+          )
           document.body.appendChild(link)
           link.click()
         })

--- a/flint.ui/src/views/gcbm/GCBMUpload.vue
+++ b/flint.ui/src/views/gcbm/GCBMUpload.vue
@@ -45,9 +45,8 @@
           <div class="flex flex-col mt-4">
             <StepperStatic />
 
-            <div class="flex flex-wrap my-5">
-              <div class="w-full lg:w-6/12 xl:w-3/12 px-4 content-center" />
-              <div class="w-full lg:w-6/12 xl:w-6/12 px-4 content-center">
+            <div class="w-full my-5">
+              <div class="w-6/12 px-4 mx-auto content-center">
                 <div
                   class="
                     relative
@@ -95,15 +94,10 @@
                   </div>
                 </div>
               </div>
-
-              <div class="w-full lg:w-6/12 xl:w-3/12 px-4 content-center" />
             </div>
-
-            <!-- <div class="flex flex-wrap my-5"> -->
             <div class="w-full px-4 content-center">
               <FileUpload ref="gcbmFileUpload" />
             </div>
-            <!-- </div> -->
           </div>
         </div>
       </div>
@@ -152,15 +146,12 @@ export default {
       return this.$store.state.gcbm.DropdownSelectedSim
     },
     getSimulations: function () {
-      //axios.get('http://localhost:8081/gcbm/ + selected_simulation)
       axios.get('http://localhost:8081/gcbm/list').then((response) => {
         this.simulation_list = response.data.data
         console.log(this.simulation_list)
-        this.$toast.success(`Ongoing simulations - ${response.data.data}`, {
+        this.$toast.info(`Ongoing simulations - ${response.data.data}`, {
           timeout: 5000
         })
-        // console.log(response.data)
-        // this.simulation_list.append
         console.log(response.data.data)
         console.log(this.simulation_list)
       })


### PR DESCRIPTION
## Description

- The `GCBM` sim run involved checking the status of the ongoing simulation and once the simulation is complete, users can `download` the result. With the toggle `enable`, this checks for the simulation status every `30 secs`, and auto downloads when the simulation is complete.
- console.log statements in production environment is considered a bad practice and should be removed, the `babel-plugin-transform-remove-console` helps take care of that.

## Testing


https://user-images.githubusercontent.com/58583793/132050502-d8d1f5a2-cd7b-49e2-b97f-203d21391da0.mov



Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! --->
