### PR TITLE
fix: Irregular card size

### DIFF
--- a/flint.ui/src/components/Cards/CardInfoConfig.vue
+++ b/flint.ui/src/components/Cards/CardInfoConfig.vue
@@ -42,10 +42,10 @@
           >
             <i class="far fa-edit" /> {{ cardFunctionConfig }}
           </button>
-        </div>
         <p class="text-sm text-blueGray-400 mt-4">
           <span class="whitespace-nowrap">{{ cardDescription }}</span>
         </p>
+        </div>
       </div>
     </div>
   </div>

--- a/flint.ui/src/components/Cards/CardInfoRun.vue
+++ b/flint.ui/src/components/Cards/CardInfoRun.vue
@@ -49,10 +49,10 @@
             @close="closeConfirmRunModal"
             @startApicalls="startApiCalls({ cardMethodName })"
           />
-        </div>
         <p class="text-sm text-blueGray-400 mt-4">
           <span class="whitespace-nowrap">{{ cardDescription }}</span>
         </p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

The size of cards is not proper because of the wrong alignment of `{{ cardDescription }}`.

![Screenshot 2021-09-05 at 10 44 47 PM](https://user-images.githubusercontent.com/42106787/132135624-38b68b65-9296-4b24-b118-235b0d8d98c9.jpg)

## Fix

![Screenshot 2021-09-05 at 10 45 50 PM](https://user-images.githubusercontent.com/42106787/132135652-9a056e38-75f0-4f77-898f-1fc853c2b0a2.jpg)
