### PR TITLE
feat: Ignore irrelevant paths from Chromatic & add Dependabot for submodule update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+# Update dependencies
+
+version: 2
+updates:
+  # Update the git submodules
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "Flint.Cloud submodule"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,10 +1,22 @@
 # .github/workflows/chromatic.yml
 
 # Workflow name
-name: 'Chromatic'
+name: "Chromatic"
 
 # Event for the workflow
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    paths:
+      - "!*"
+      - "flint.ui/.storybook/**"
+      - "flint.ui/src/stories/**"
+  pull_request:
+    branches: [master]
+    paths:
+      - "!*"
+      - "flint.ui/.storybook/**"
+      - "flint.ui/src/stories/**"
 
 # List of jobs
 jobs:


### PR DESCRIPTION
- [x] Added Dependabot to update `Flint.Cloud` submodule means Dependabot will make a PR automatically whenever new changes are pushed to `Flint.Cloud` repository. This will help the submodule in Flint UI to be consistent with the main `Flint.Cloud` repository.
- [x] Currently, Chromatic GitHub action runs for every commit which might affect the usage limits for GitHub Actions workflows. So, we can ignore files that do not require Chromatic Action. We can run Chromatic only when there is a change in relevant files i.e. `flint.ui/.storybook/**` and `flint.ui/src/stories/*`.
