### PR TITLE
feat: Formatted step date column from ISO 8601 date to `YYYY-MM-DD` form

### DIFF
--- a/flint.ui/src/views/flint/TablePoint.vue
+++ b/flint.ui/src/views/flint/TablePoint.vue
@@ -72,7 +72,7 @@ export default {
         {
           prop: 'point_stepDate',
           name: 'stepDate',
-          size: 200
+          size: 150
         },
         {
           prop: 'point_stepLenInYears',
@@ -152,14 +152,14 @@ export default {
       console.log(pool_2)
       console.log('pool_3 from generateDataRows')
       console.log(pool_3)
-
       for (let j = 0; j < point_step.length; j++) {
         let row = j
         if (!result[row]) {
           result[row] = {}
         }
         result[row]['point_step'] = point_step[row]
-        result[row]['point_stepDate'] = point_stepDate[row]
+        var defaultDateFormat = new Date(point_stepDate[row])
+        result[row]['point_stepDate'] = defaultDateFormat.toISOString().substring(0, 10);
         result[row]['point_stepLenInYears'] = point_stepLenInYears[row].toPrecision(5)
         result[row]['pool_1'] = pool_1[row].toPrecision(5)
         result[row]['pool_2'] = pool_2[row].toPrecision(5)

--- a/flint.ui/src/views/flint/TableRothC.vue
+++ b/flint.ui/src/views/flint/TableRothC.vue
@@ -71,12 +71,12 @@ export default {
         {
           prop: 'RothC_stepDate',
           name: 'stepDate',
-          size: 200
+          size: 150
         },
         {
           prop: 'plantCM',
           name: 'plantCM',
-          size: 100
+          size: 150
         },
         {
           prop: 'DPM',
@@ -106,7 +106,7 @@ export default {
         {
           prop: 'IOM',
           name: 'SoilIOM',
-          size: 100
+          size: 150
         },
         {
           prop: 'atmosphere',
@@ -206,7 +206,8 @@ export default {
           result[row] = {}
         }
         result[row]['RothC_step'] = RothC_step[row]
-        result[row]['RothC_stepDate'] = RothC_stepDate[row]
+        var defaultDateFormat = new Date(RothC_stepDate[row])
+        result[row]['RothC_stepDate'] = defaultDateFormat.toISOString().substring(0, 10)
         result[row]['DPM'] = DPM[row].toPrecision(5)
         result[row]['RPM'] = RPM[row].toPrecision(5)
         result[row]['BIOF'] = BIOF[row].toPrecision(5)


### PR DESCRIPTION
## Description

JavaScript supports ISO 8601 date format by default i.e. `YYYY-MM-DDTHH:mm:ss.sssZ` but when we are running a simulation for hundreds of years then hours, minutes, and seconds don't matter very much so we only care about the date.

Fixes: #93

#### Point Output Table

![Screenshot 2021-10-13 at 6 13 10 AM](https://user-images.githubusercontent.com/42106787/137047773-a368fa47-e5bf-4bcf-9cbb-308893c14bd5.jpg)

#### RothC Output Table

![Screenshot 2021-10-13 at 6 12 59 AM](https://user-images.githubusercontent.com/42106787/137047769-145c1c38-ca1a-4611-8bc5-a6a74b757c19.jpg)
