### PR TITLE
Refactored repetitive string manipulation methods under a single method

### DIFF
--- a/flint.ui/src/mixins/formatData.js
+++ b/flint.ui/src/mixins/formatData.js
@@ -1,0 +1,10 @@
+export default {
+    methods: {
+        formatDecimal(inputString) {
+            return inputString.substr(2).slice(0, -2)
+        },
+        formatArray(inputString) {
+            return inputString.substr(4).slice(0, -4)
+        }
+    }
+}

--- a/flint.ui/src/views/flint/configurations/rothc/RothCAvgAirTemp.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCAvgAirTemp.vue
@@ -71,17 +71,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_avgAirTemp_data_orig: {
       get() {
-        return this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_orig
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_orig)
       },
       set(newValue) {
         this.$store.commit(
@@ -93,9 +93,7 @@ export default {
 
     newconfig_avgAirTemp_data_month_avg: {
       get() {
-        return this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_month_avg
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_month_avg)
       },
       set(newValue) {
         this.$store.commit(
@@ -107,9 +105,7 @@ export default {
 
     newconfig_avgAirTemp_data_lastyearcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_lastyearcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[10].avgAirTemp.transform.data_lastyearcopy)
       },
       set(newValue) {
         this.$store.commit(

--- a/flint.ui/src/views/flint/configurations/rothc/RothCInitSoil.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCInitSoil.vue
@@ -200,17 +200,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_dpmaCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.dpmaCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.dpmaCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_dpmaCMInit', '$#' + newValue + '$#')
@@ -219,9 +219,7 @@ export default {
 
     newconfig_rpmaCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.rpmaCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.rpmaCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_rpmaCMInit', '$#' + newValue + '$#')
@@ -230,9 +228,7 @@ export default {
 
     newconfig_biofCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.biofCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.biofCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_biofCMInit', '$#' + newValue + '$#')
@@ -241,9 +237,7 @@ export default {
 
     newconfig_biosCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.biosCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.biosCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_biosCMInit', '$#' + newValue + '$#')
@@ -252,9 +246,7 @@ export default {
 
     newconfig_humsCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.humsCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.humsCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_humsCMInit', '$#' + newValue + '$#')
@@ -263,9 +255,7 @@ export default {
 
     newconfig_inrtCMInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.inrtCMInit
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.inrtCMInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_inrtCMInit', '$#' + newValue + '$#')
@@ -274,9 +264,7 @@ export default {
 
     newconfig_TSMDInit: {
       get() {
-        return this.$store.state.rothc.config.Variables[13].initSoil.TSMDInit.substr(
-          2
-        ).slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[13].initSoil.TSMDInit)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_TSMDInit', '$#' + newValue + '$#')

--- a/flint.ui/src/views/flint/configurations/rothc/RothCOpenPanEvap.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCOpenPanEvap.vue
@@ -71,17 +71,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_openPanEvap_data_orig: {
       get() {
-        return this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_orig
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_orig)
       },
       set(newValue) {
         this.$store.commit(
@@ -93,9 +93,7 @@ export default {
 
     newconfig_openPanEvap_data_month_avg: {
       get() {
-        return this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_month_avg
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_month_avg)
       },
       set(newValue) {
         this.$store.commit(
@@ -107,9 +105,7 @@ export default {
 
     newconfig_openPanEvap_data_lastyearcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_lastyearcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[9].openPanEvap.transform.data_lastyearcopy)
       },
       set(newValue) {
         this.$store.commit(

--- a/flint.ui/src/views/flint/configurations/rothc/RothCPresCM.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCPresCM.vue
@@ -69,17 +69,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_presCM_data_orig: {
       get() {
-        return this.$store.state.rothc.config.Variables[11].presCM.transform.data_orig
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[11].presCM.transform.data_orig)
       },
       set(newValue) {
         this.$store.commit(
@@ -91,9 +91,7 @@ export default {
 
     newconfig_presCM_data_month_avg: {
       get() {
-        return this.$store.state.rothc.config.Variables[11].presCM.transform.data_month_avg
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[11].presCM.transform.data_month_avg)
       },
       set(newValue) {
         this.$store.commit(
@@ -105,9 +103,7 @@ export default {
 
     newconfig_presCM_data_lastyearcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[11].presCM.transform.data_lastyearcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[11].presCM.transform.data_lastyearcopy)
       },
       set(newValue) {
         this.$store.commit(

--- a/flint.ui/src/views/flint/configurations/rothc/RothCRainfall.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCRainfall.vue
@@ -71,17 +71,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_rainfall_data_orig: {
       get() {
-        return this.$store.state.rothc.config.Variables[8].rainfall.transform.data_orig
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[8].rainfall.transform.data_orig)
       },
       set(newValue) {
         this.$store.commit(
@@ -93,9 +93,7 @@ export default {
 
     newconfig_rainfall_data_month_avg: {
       get() {
-        return this.$store.state.rothc.config.Variables[8].rainfall.transform.data_month_avg
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[8].rainfall.transform.data_month_avg)
       },
       set(newValue) {
         this.$store.commit(
@@ -107,9 +105,7 @@ export default {
 
     newconfig_rainfall_data_lastyearcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[8].rainfall.transform.data_lastyearcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[8].rainfall.transform.data_lastyearcopy)
       },
       set(newValue) {
         this.$store.commit(

--- a/flint.ui/src/views/flint/configurations/rothc/RothCSoil.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCSoil.vue
@@ -415,17 +415,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_bToCMaxTSMDRatio: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.bToCMaxTSMDRatio
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.bToCMaxTSMDRatio)
       },
       set(newValue) {
         this.$store.commit(
@@ -437,9 +437,7 @@ export default {
 
     newconfig_dToRRatioInPres: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.dToRRatioInPres
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.dToRRatioInPres)
       },
       set(newValue) {
         this.$store.commit(
@@ -451,9 +449,7 @@ export default {
 
     newconfig_encpFracHums: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.encpFracHums
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.encpFracHums)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_encpFracHums', '$#' + newValue + '$#')
@@ -462,9 +458,7 @@ export default {
 
     newconfig_evapoOpenRatio: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.evapoOpenRatio
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.evapoOpenRatio)
       },
       set(newValue) {
         this.$store.commit(
@@ -476,9 +470,7 @@ export default {
 
     newconfig_fracHumsToBios: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracHumsToBios
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracHumsToBios)
       },
       set(newValue) {
         this.$store.commit(
@@ -490,9 +482,7 @@ export default {
 
     newconfig_fracManuCMToBiof: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracManuCMToBiof
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracManuCMToBiof)
       },
       set(newValue) {
         this.$store.commit(
@@ -504,9 +494,7 @@ export default {
 
     newconfig_fracManuCMToBios: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracManuCMToBios
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracManuCMToBios)
       },
       set(newValue) {
         this.$store.commit(
@@ -518,9 +506,7 @@ export default {
 
     newconfig_fracManuCMToDpma: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracManuCMToDpma
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracManuCMToDpma)
       },
       set(newValue) {
         this.$store.commit(
@@ -532,9 +518,7 @@ export default {
 
     newconfig_fracManuCMToRpma: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracManuCMToRpma
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracManuCMToRpma)
       },
       set(newValue) {
         this.$store.commit(
@@ -546,9 +530,7 @@ export default {
 
     newconfig_fracPbioToBiof: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.fracPbioToBiof
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.fracPbioToBiof)
       },
       set(newValue) {
         this.$store.commit(
@@ -560,9 +542,7 @@ export default {
 
     newconfig_sampleDepth: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sampleDepth
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sampleDepth)
       },
       set(newValue) {
         this.$store.commit('setNewConfig_sampleDepth', '$#' + newValue + '$#')
@@ -571,9 +551,7 @@ export default {
 
     newconfig_sdcmRateMultBiof: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultBiof
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultBiof)
       },
       set(newValue) {
         this.$store.commit(
@@ -585,9 +563,7 @@ export default {
 
     newconfig_sdcmRateMultBios: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultBios
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultBios)
       },
       set(newValue) {
         this.$store.commit(
@@ -599,9 +575,7 @@ export default {
 
     newconfig_sdcmRateMultDpm: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultDpm
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultDpm)
       },
       set(newValue) {
         this.$store.commit(
@@ -613,9 +587,7 @@ export default {
 
     newconfig_sdcmRateMultHums: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultHums
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultHums)
       },
       set(newValue) {
         this.$store.commit(
@@ -627,9 +599,7 @@ export default {
 
     newconfig_sdcmRateMultRpm: {
       get() {
-        return this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultRpm
-          .substr(2)
-          .slice(0, -2)
+        return this.formatDecimal(this.$store.state.rothc.config.Variables[14].soil.sdcmRateMultRpm)
       },
       set(newValue) {
         this.$store.commit(

--- a/flint.ui/src/views/flint/configurations/rothc/RothCSoilCover.vue
+++ b/flint.ui/src/views/flint/configurations/rothc/RothCSoilCover.vue
@@ -84,17 +84,17 @@
 
 <script>
 import Stepper from '@/components/Stepper/StepperRothc.vue'
+import formatData from '@/mixins/formatData'
 
 export default {
   components: {
     Stepper
   },
+  mixins: [formatData],
   computed: {
     newconfig_soilcover_data_orig: {
       get() {
-        return this.$store.state.rothc.config.Variables[12].soilCover.transform.data_orig
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[12].soilCover.transform.data_orig)
       },
       set(newValue) {
         this.$store.commit(
@@ -106,9 +106,7 @@ export default {
 
     newconfig_soilcover_data_firstmonthcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[12].soilCover.transform.data_firstmonthcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[12].soilCover.transform.data_firstmonthcopy)
       },
       set(newValue) {
         this.$store.commit(
@@ -120,9 +118,7 @@ export default {
 
     newconfig_soilcover_data_month_avg: {
       get() {
-        return this.$store.state.rothc.config.Variables[12].soilCover.transform.data_month_avg
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[12].soilCover.transform.data_month_avg)
       },
       set(newValue) {
         this.$store.commit(
@@ -134,9 +130,7 @@ export default {
 
     newconfig_soilcover_data_lastyearcopy: {
       get() {
-        return this.$store.state.rothc.config.Variables[12].soilCover.transform.data_lastyearcopy
-          .substr(4)
-          .slice(0, -4)
+        return this.formatArray(this.$store.state.rothc.config.Variables[12].soilCover.transform.data_lastyearcopy)
       },
       set(newValue) {
         this.$store.commit(


### PR DESCRIPTION
Signed-off-by: waridrox <mohdwarid4@gmail.com>

# Pull Request Template

## Description

- Currently, the values for the configs are protected by characters like `#$` and `#$ [` / `] #$` to prevent loss of data. (See #13). This was achieved using `substr` and `slice` methods which was repetitive. 
- Methods namely `arrayInputManipulation` and `decimalInputManipulation` added to achieve the same.


## Testing

Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! --->
