### PR TITLE
FEAT: Add a dev container for Docker development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# To fully customize the contents of this image, use the following Dockerfile instead:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.112.0/containers/typescript-node-12/.devcontainer/Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12
+
+RUN npm install -g @vue/cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+	// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+	// https://github.com/microsoft/vscode-dev-containers/tree/v0.112.0/containers/typescript-node-12
+	"name": "Vue CLI & Node.js 12 & TypeScript",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/zsh",
+		"files.trimTrailingWhitespace": true,
+		"editor.formatOnSave": true,
+		"editor.codeActionsOnSave": {
+			"source.fixAll.eslint": true
+		},
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"octref.vetur",
+		"dariofuzinato.vue-peek",
+		"esbenp.prettier-vscode",
+		"formulahendry.auto-rename-tag",
+		"christian-kohler.path-intellisense",
+		"CoenraadS.bracket-pair-colorizer",
+		"streetsidesoftware.code-spell-checker",
+		"VisualStudioExptTeam.vscodeintellicode",
+		"mhutchie.git-graph"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8000,
+	],
+}


### PR DESCRIPTION
## Description

This PR:

- Adds a `devcontainer.json`
- Adds a Dockerfile to be built with `.devcontainer`

This PR would facilitate all the developers to start building inside a development container with a well-defined tool and runtime stack.