### PR TITLE
Add Contact Us to Navbar

### DIFF
--- a/flint.ui/src/components/Navbars/LandingPageNavbar.vue
+++ b/flint.ui/src/components/Navbars/LandingPageNavbar.vue
@@ -57,6 +57,12 @@
             <a href="https://github.com/moja-global/FLINT-UI"> GitHub </a>
           </button>
         </a>
+
+        <a class="block mt-4 text-lg px-0 lg:px-8 lg:inline-block lg:mt-0">
+          <button class="hover:text-earth">
+            <a href="mailto:info@moja.global"> Contact Us </a>
+          </button>
+        </a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
# Pull Request Template

For now, the navbar only shows Documentation and Github. The new "Contact Us" element will be redirected to the organisation's email.

#133 

## Testing

Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)

...

<!--- Thanks for opening this pull request! --->
