### PR TITLE
Changed step-3 of installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git submodule update --init --recursive
 3. Now get inside the repository directory and build the `docker-compose.yml` file by following the below command:
 
 ```shell
-docker-compose up
+docker-compose build
 ```
 
 This will build all the docker images inside the `docker-compose.yml` file. It will take some time and after that, you can see all images list in the Docker app.


### PR DESCRIPTION

# Pull Request Template

## Description

The step-3 of installation is building the docker image. However instead of the build command there is `docker-compose up` in the README. I changed it to `docker-compose build`.

## Testing


## Additional Context (Please include any Screenshots/gifs if relevant)
![image](https://user-images.githubusercontent.com/76250591/157399692-e6f4e27e-b5a7-47ed-b344-1034f8ec445a.png)

...
Signed-off-by: Hitansh Shah <shah.hitanshsanjay.mat20@itbhu.ac.in>
<!--- Thanks for opening this pull request! --->
