### PR TITLE
feat: removed the visualize on graph button

### DIFF
--- a/flint.ui/src/views/flint/PointOutput.vue
+++ b/flint.ui/src/views/flint/PointOutput.vue
@@ -100,6 +100,8 @@ export default {
 </script>
 <style>
 div.chart-wrapper {
-  padding-top: 150px;
+  padding-top: 60px !important;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 </style>

--- a/flint.ui/src/views/flint/TablePoint.vue
+++ b/flint.ui/src/views/flint/TablePoint.vue
@@ -1,32 +1,10 @@
 <template>
+<div>
   <div class="relative bg-gradient-to-r from-green-400 to-blue-500 md:pt-32 pt-12 w-full h-full">
     <div class="mx-auto w-full h-auto">
       <div>
         <div class="bg-white p-6 rounded-lg shadow-lg flex">
           <h2 class="text-2xl font-bold text-gray-800 flex-1">Point example data visualisation table</h2>
-
-          <router-link to="/flint/point_output">
-            <div data-v-step="1">
-              <button
-                class="
-                  inline-block
-                  align-middle
-                  flex-initial
-                  bg-white
-                  hover:bg-black hover:text-white
-                  text-gray-800
-                  font-semibold
-                  py-2
-                  px-4
-                  border border-gray-400
-                  rounded
-                  shadow
-                "
-              >
-                <i class="far fa-image" /> Visualise on Graph
-              </button>
-            </div>
-          </router-link>
         </div>
       </div>
     </div>
@@ -35,14 +13,19 @@
     </div>
     <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
   </div>
+  <PointOutput />
+  </div>
 </template>
 
 <script>
 /* eslint-disable */
 import VGrid from '@revolist/vue-datagrid'
+import PointOutput from './PointOutput.vue'
+
 export default {
   components: {
-    VGrid
+    VGrid,
+    PointOutput
   },
   data() {
     return {
@@ -181,20 +164,5 @@ export default {
 </script>
 
 <style>
-revo-grid {
-  height: 100%;
-}
 
-div .rgHeaderCell, .header-rgRow{
-  background: #000000;
-  color: #fff;
-}
-
-div .header-content {
-  color: #fff;
-}
-
-.rgCell {
-  background-color: #fff;
-}
 </style>


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #230 

## Testing

 
## Additional Context (Please include any Screenshots/gifs if relevant)
when we click on the point output table option on the simulator page it leads to 
![image](https://user-images.githubusercontent.com/87171452/162602739-620065fc-2131-4f3b-a557-13aed8da3f10.png)

clicking on visualize on graph leads to 
![image](https://user-images.githubusercontent.com/87171452/162602767-3a9cbedc-1253-4045-bea5-2bf38b184a39.png)

in this I have removed the visualize on graph button and print the graph on the previous page 
![image](https://user-images.githubusercontent.com/87171452/162602796-0b94bb6b-11ac-4e58-9a73-6a541710372d.png)


 
 
<!--- Thanks for opening this pull request! --->

@HarshCasper @chicken-biryani can you please once review it :) 