### PR TITLE
Updated simulation length in Point dynamically

### DIFF
--- a/flint.ui/src/components/Datepicker/DatepickerPoint.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerPoint.vue
@@ -4,7 +4,7 @@
     <input v-model="selectedstartDate" type="date" class="datepicker-input" :class="[size]" />
 
     <md-button class="md-primary">End Date</md-button>
-    <input v-modal="selectedendDate" type="date" class="datepicker-input" :class="[size]" />
+    <input v-model="selectedendDate" type="date" class="datepicker-input" :class="[size]" />
 
     <h3 class="text-xl font-bold mb-2 text-gray-600 justify-center">
       Simulation length is

--- a/flint.ui/src/views/flint/ConfigurationsPoint.vue
+++ b/flint.ui/src/views/flint/ConfigurationsPoint.vue
@@ -85,13 +85,6 @@
           </div>
         </div>
 
-        <div class="mt-16 text-xl mb-2 text-earth">
-          Simulation length is
-          <!-- This can be updated later when we have the
-            DatepickerPoint component ready with the new UI. -->
-          <span class="text-blue-500">4.92 years</span>
-        </div>
-
         <div class="my-16 flex gap-8 items-center">
           <div data-v-step="5"><Button @click.native="Run()">Run</Button></div>
           <div data-v-step="6">


### PR DESCRIPTION
## Description
Fixes #207 
The simulation length was not changing dynamically. Resolved errors to make it change based on selected start and end dates.

## Testing
1) Go on the Point page.
2) Change start or end dates.
3) Check the updated simulation length.

