### PR TITLE
fix: extra width fixes of configuration cards of RothC 

### DIFF
--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <div class="mb-10 mx-5 w-full md:justify-center">
+    <div class="mb-10 mx-5  md:justify-center">
       <LandingPageNavbar />
-      <div class="md:px-10 ml-10 w-full md:justify-center">
+      <div class="md:px-10 ml-10  md:justify-center">
         <div>
           <h2 class="mb mt-7 py-4 text-2xl text-earth">RothC example simulation configuration</h2>
           <p class="text-earth sm:text-base">


### PR DESCRIPTION
# fix: extra width fixes of configuration cards of RothC 


## Description

This pr fixes the Extra width of configuration cards of RothC  #237 



## Testing

Please instructions so we can verify your changes.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

## Additional Context (Please include any Screenshots/gifs if relevant)
<img width="1440" alt="Screenshot 2022-04-17 at 11 26 06 PM" src="https://user-images.githubusercontent.com/54894783/163726510-f8a00860-50db-4c99-a82b-36e17b3dadaf.png">
<img width="1440" alt="Screenshot 2022-04-17 at 11 26 06 PM" src="https://user-images.githubusercontent.com/54894783/163726711-138689fa-0dbf-40e5-8a30-047f2d578e5d.gif">


...

<!--- Thanks for opening this pull request! --->
