### PR TITLE
Text alignment fix on RothC page.

### DIFF
--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -20,7 +20,7 @@
             <div class="py-6 mb-3">
               <h2 class="text-xl font-normal text-earth text-base">Start and End date of simulation</h2>
               <div>
-                <div class=" text-2xl font-normal text-gray"><Datepicker size="small" /></div>
+                <div class="text-2xl font-normal text-gray"><Datepicker size="small" /></div>
               </div>
             </div>
           </div>

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="mb-10 mx-5 md:justify-center">
       <LandingPageNavbar />
-      <div class="md:px-10 ml-10 md:justify-center">
+      <div class="px-8 pb-6 sm:px-16 md:px-24">
         <div>
           <h2 class="mb mt-7 py-4 text-2xl text-earth">RothC example simulation configuration</h2>
           <p class="text-earth sm:text-base">

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
-    <div class="mb-10 mx-5  md:justify-center">
+    <div class="mb-10 mx-5 md:justify-center">
       <LandingPageNavbar />
-      <div class="md:px-10 ml-10  md:justify-center">
+      <div class="md:px-10 ml-10 md:justify-center">
         <div>
           <h2 class="mb mt-7 py-4 text-2xl text-earth">RothC example simulation configuration</h2>
           <p class="text-earth sm:text-base">
             Was the simulation conducted at a specific place ? Click
             <span>here</span> to save latitude and longitude co-ordinates
           </p>
-          <p class="md:px-24 text-earth text-base">
+          <p class="text-earth text-base">
             Input the custom values in the fields below. Default values as placeholder text will be used if none
             provided.
           </p>
@@ -18,9 +18,9 @@
         <div class="mt-10">
           <div>
             <div class="py-6 mb-3">
-              <h2 class="text-xl font-normal md:px-24 text-earth text-base">Start and End date of simulation</h2>
+              <h2 class="text-xl font-normal text-earth text-base">Start and End date of simulation</h2>
               <div>
-                <div class="md:px-24 text-2xl font-normal text-gray"><Datepicker size="small" /></div>
+                <div class=" text-2xl font-normal text-gray"><Datepicker size="small" /></div>
               </div>
             </div>
           </div>

--- a/flint.ui/src/views/flint/TablePoint.vue
+++ b/flint.ui/src/views/flint/TablePoint.vue
@@ -1,19 +1,19 @@
 <template>
-<div>
-  <div class="relative bg-gradient-to-r from-green-400 to-blue-500 md:pt-32 pt-12 w-full h-full">
-    <div class="mx-auto w-full h-auto">
-      <div>
-        <div class="bg-white p-6 rounded-lg shadow-lg flex">
-          <h2 class="text-2xl font-bold text-gray-800 flex-1">Point example data visualisation table</h2>
+  <div>
+    <div class="relative bg-gradient-to-r from-green-400 to-blue-500 md:pt-32 pt-12 w-full h-full">
+      <div class="mx-auto w-full h-auto">
+        <div>
+          <div class="bg-white p-6 rounded-lg shadow-lg flex">
+            <h2 class="text-2xl font-bold text-gray-800 flex-1">Point example data visualisation table</h2>
+          </div>
         </div>
       </div>
+      <div class="h-2/3 mt-12 px-6">
+        <v-grid style="height: 100%" theme="default" :source="rows" :columns="columns" :readonly="true"></v-grid>
+      </div>
+      <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
     </div>
-    <div class="h-2/3 mt-12 px-6">
-      <v-grid style="height: 100%" theme="default" :source="rows" :columns="columns" :readonly="true"></v-grid>
-    </div>
-    <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
-  </div>
-  <PointOutput />
+    <PointOutput />
   </div>
 </template>
 


### PR DESCRIPTION
## Description

Content on the RothC page was not properly aligned. It is now aligned properly.
fixes #226.

## Testing

## Additional Context (Please include any Screenshots/gifs if relevant)
![FireShot Capture 011 - moja global FLINT UI - localhost](https://user-images.githubusercontent.com/63044364/165947201-8066b455-3d18-46cc-8617-e0cc8f233235.png)

...

<!--- Thanks for opening this pull request! --->
@all-contributors please add @timonwa for bug