### PR TITLE
Add description text to configuration parameters cards for RothC

### DIFF
--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -31,17 +31,17 @@
         <div class="flex flex-wrap mt-5">
           <Accordion config-paramtype="rainfall" />
 
-          <RothCTemplate config-paramtype="openPanEvap" />
+          <RothCTemplate config-paramtype="openPanEvap" config-paramtext="Open Pan Evaporation" />
 
-          <RothCTemplate config-paramtype="avgAirTemp" />
+          <RothCTemplate config-paramtype="avgAirTemp" config-paramtext="Average Air Temperature"/>
 
-          <RothCTemplate config-paramtype="presCM" />
+          <RothCTemplate config-paramtype="presCM" config-paramtext="Organic carbon inputs" />
 
-          <RothCTemplate config-paramtype="soilCover" />
+          <RothCTemplate config-paramtype="soilCover" config-paramtext="Soil Cover" />
 
-          <RothCTemplate config-paramtype="initSoil" />
+          <RothCTemplate config-paramtype="initSoil" config-paramtext="Initial conditions of the Soil" />
 
-          <RothCTemplate config-paramtype="soil" />
+          <RothCTemplate config-paramtype="soil" config-paramtext="Soil characteristics" />
         </div>
         <div class="mt-4 mb-5">
           <Button :btn-size="'auto'" @click.native="apiRoute_rothc">Run</Button>

--- a/flint.ui/src/views/flint/RothCTemplate.vue
+++ b/flint.ui/src/views/flint/RothCTemplate.vue
@@ -5,7 +5,7 @@
         <div class="flex flex-wrap">
           <div class="relative w-full max-w-full flex-grow flex-1">
             <p class="text-center w-full font-semibold text-md text-blueGray-700 my-4">
-              Update parameters for {{ configParamtype }}
+              Update parameters for {{configParamtext}} ({{ configParamtype }})
             </p>
             <button
               class="
@@ -40,6 +40,10 @@ export default {
   name: 'CardRothConfig',
   components: {},
   props: {
+    configParamtext: {
+      type: String,
+      default: 'configuration parameter'
+    },
     configParamtype: {
       type: String,
       default: 'Config params for xyz'


### PR DESCRIPTION
## Description

Added user-friendly text to display for the user to know what the configuration parameters means for the RothC simulation.

## Testing

Just launch vue server and go to `http://localhost:8001//flint/configurations/rothc`

## Additional Context (Please include any Screenshots/gifs if relevant)

![image](https://user-images.githubusercontent.com/2631430/165073784-0b6583ac-0a01-40ec-8f7e-00ab32740ece.png)

<!--- Thanks for opening this pull request! --->
