### PR TITLE
Updated TablePoint.vue file to use Ant Design Tables

### DIFF
--- a/flint.ui/src/components/Datepicker/DatepickerPoint.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerPoint.vue
@@ -4,7 +4,7 @@
     <input v-model="selectedstartDate" type="date" class="datepicker-input" :class="[size]" />
 
     <md-button class="md-primary">End Date</md-button>
-    <input v-modal="selectedendDate" type="date" class="datepicker-input" :class="[size]" />
+    <input v-model="selectedendDate" type="date" class="datepicker-input" :class="[size]" />
 
     <h3 class="text-xl font-bold mb-2 text-gray-600 justify-center">
       Simulation length is

--- a/flint.ui/src/routes/routes.js
+++ b/flint.ui/src/routes/routes.js
@@ -14,7 +14,7 @@ import RothCInitSoil from '@/views/flint/configurations/rothc/RothCInitSoil.vue'
 import RothCSoil from '@/views/flint/configurations/rothc/RothCSoil.vue'
 
 import PointOutput from '@/views/flint/PointOutput.vue'
-import TablePoint from '@/views/flint/TablePoint.vue'
+import PointOuterTable from '@/views/flint/PointOuterTable.vue'
 import TableRothC from '@/views/flint/TableRothC.vue'
 import RothCOutput from '@/views/flint/RothCOutput.vue'
 
@@ -78,7 +78,7 @@ const routes = [
       },
       {
         path: '/flint/point_output_table',
-        component: TablePoint
+        component: PointOuterTable
       },
       {
         path: '/flint/point_output',

--- a/flint.ui/src/views/flint/ConfigurationsPoint.vue
+++ b/flint.ui/src/views/flint/ConfigurationsPoint.vue
@@ -100,6 +100,7 @@
         </div>
       </div>
       <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
+      <PointOuterTable v-if="showTable"/>
     </div>
     <Footer />
   </div>
@@ -111,6 +112,7 @@ import Datepicker from '@/components/Datepicker/DatepickerPoint.vue'
 import LandingPageNavbar from '@/components/Navbars/LandingPageNavbar.vue'
 import Maptest from '@/components/Vuelayers/Maptest.vue'
 import Footer from '@/components/Footer/Footer.vue'
+    import PointOuterTable from './PointOuterTable.vue'
 
 export default {
   components: {
@@ -118,12 +120,13 @@ export default {
     Datepicker,
     LandingPageNavbar,
     Maptest,
-    Footer
+    Footer,
+    PointOuterTable
   },
   data() {
     return {
       isShow: false,
-
+      showTable: false,
       pool1: {
         min: 0.0,
         max: 400.0,
@@ -220,13 +223,12 @@ export default {
     },
 
     Run() {
-      this.$root.$refs.finalPoolValues() //This does whatever the stepper does.
+        this.$root.$refs.finalPoolValues() //This does whatever the stepper does.
+        this.showTable = false
     },
 
     showPointOutputTable() {
-      // this is a temporary function which can be removed when we have the
-      // PointOutputTable component ready.
-      this.$router.push('/flint/point_output_table')
+        this.showTable = true
     }
   }
 }

--- a/flint.ui/src/views/flint/PointOuterTable.vue
+++ b/flint.ui/src/views/flint/PointOuterTable.vue
@@ -13,7 +13,7 @@
 
 <script>
 
-    /* eslint-disable */
+   /* eslint-disable no-alert, no-console */
     import PointOutput from './PointOutput.vue'
     import Table from './Table.vue'
 

--- a/flint.ui/src/views/flint/PointOuterTable.vue
+++ b/flint.ui/src/views/flint/PointOuterTable.vue
@@ -6,7 +6,7 @@
             </div>
             <div class="full-w">
                 <PointOutput v-if="!isTable" />
-                <TablePoint v-else :columns="columns" :rows="rows" />
+                <Table v-else :columns="columns" :rows="rows" />
             </div>
         </div>
 </template>
@@ -15,14 +15,13 @@
 
     /* eslint-disable */
     import PointOutput from './PointOutput.vue'
-    import TablePoint from './TablePoint.vue'
+    import Table from './Table.vue'
 
     export default {
         name: "PointOuterTable",
         components: {
-            VGrid,
             PointOutput,
-            TablePoint
+            Table
         },
         data() {
             return {

--- a/flint.ui/src/views/flint/PointOuterTable.vue
+++ b/flint.ui/src/views/flint/PointOuterTable.vue
@@ -1,0 +1,146 @@
+<template>
+    <div class="outer-table">
+            <div class="top-row">
+                <div :class={active:isTable} @click="isTable= true">Table</div>
+                <div :class={active:!isTable} @click="isTable = false">Graph</div>
+            </div>
+            <div class="full-w">
+                <PointOutput v-if="!isTable" />
+                <TablePoint v-else :columns="columns" :rows="rows" />
+            </div>
+        </div>
+</template>
+
+<script>
+
+    /* eslint-disable */
+    import PointOutput from './PointOutput.vue'
+    import TablePoint from './TablePoint.vue'
+
+    export default {
+        name: "PointOuterTable",
+        components: {
+            VGrid,
+            PointOutput,
+            TablePoint
+        },
+        data() {
+            return {
+                isTable: true,
+                columns: [
+                    {
+                        title: 'Step',
+                        dataIndex: 'point_step',
+                        key: 'point_step'
+                    },
+                    {
+                        title: 'Step Date',
+                        dataIndex: 'point_stepDate',
+                        key: 'point_stepDate'
+                    },
+                    {
+                        title: 'Step Length(years)',
+                        dataIndex: 'point_stepLenInYears',
+                        key: 'point_stepLenInYears'
+                    },
+                    {
+                        title: 'Pool 1',
+                        dataIndex: 'pool_1',
+                        key: 'pool_1'
+                    },
+                    {
+                        title: 'Pool 2',
+                        dataIndex: 'pool_2',
+                        key: 'pool_2'
+                    },
+                    {
+                        title: 'Pool 3',
+                        dataIndex: 'pool_3',
+                        key: 'pool_3'
+                    }
+                ],
+
+                rows: this.generateDataRows()
+            }
+        },
+
+        methods: {
+            pool_1() {
+                return this.$store.state.point.pool_1
+            },
+            pool_2() {
+                return this.$store.state.point.pool_2
+            },
+            pool_3() {
+                return this.$store.state.point.pool_3
+            },
+            point_step() {
+                return this.$store.state.point.point_step
+            },
+            point_stepDate() {
+                return this.$store.state.point.point_stepDate
+            },
+            point_stepLenInYears() {
+                return this.$store.state.point.point_stepLenInYears
+            },
+            generateDataRows: function () {
+                var result = []
+                var pool_1 = this.pool_1(),
+                    pool_2 = this.pool_2(),
+                    pool_3 = this.pool_3(),
+                    point_step = this.point_step(),
+                    point_stepDate = this.point_stepDate(),
+                    point_stepLenInYears = this.point_stepLenInYears()
+                for (let j = 0; j < point_step.length; j++) {
+                    let original_date = point_stepDate[j];
+                    let date = original_date.substring(0, 10) + " " + original_date.substring(11);
+                    var defaultDateFormat = new Date(date);
+
+                    let row = {
+                        key: j+1,
+                        point_step: point_step[j]+1,
+                        point_stepDate: defaultDateFormat.toISOString().substring(0, 10),
+                        point_stepLenInYears: point_stepLenInYears[j].toPrecision(5),
+                        pool_1: pool_1[j].toPrecision(5),
+                        pool_2: pool_2[j].toPrecision(5),
+                        pool_3: pool_3[j].toPrecision(5)
+                    }
+                   
+                    result.push(row);
+                }
+               return result
+            }
+        },
+        beforeCreate() {
+            this.$store.dispatch('parse_point_results')
+            this.isTable=true
+        },
+    }
+</script>
+
+<style>
+    .outer-table {
+        border: 1px solid #475447;
+        border-radius:5px;
+    }
+
+    .top-row {
+        display: flex;
+        flex-direction: row;
+        border-bottom: 2px solid #EEEEF0
+    }
+
+    .top-row div{
+        width:50%;
+        text-align:center;
+        padding:16px;
+        cursor:pointer
+    }
+
+    .top-row .active{
+        color:white;
+        background-color:#475447
+    }
+</style>
+
+ 

--- a/flint.ui/src/views/flint/Table.vue
+++ b/flint.ui/src/views/flint/Table.vue
@@ -1,0 +1,75 @@
+<template>
+    <div class="w-full h-full">
+        <a-table :data-source="r" :columns="c"/>
+    </div>
+</template>
+<script>
+    /* eslint-disable */
+    import Table from 'ant-design-vue'
+
+    export default {
+        name: "Table",
+        components: {
+            Table
+        },
+        props: ['rows', 'columns'],
+
+        data() {
+            return {
+                c: this.columns,
+                r: this.rows
+            }
+        },
+    }
+</script>
+
+<style>
+    thead.ant-table-thead tr th {
+        color: white;
+        background-color: #475447;
+        border: 2px solid #EEEEF0;
+        text-align: center
+    }
+
+    .ant-table-row td {
+        border: 2px solid #EEEEF0;
+        text-align: center
+    }
+
+    .ant-table-thead > tr:first-child > th:first-child, .ant-table-row-cell-last {
+        border-radius: 0px !important;
+    }
+
+    .ant-table-thead > tr:first-child > th:first-child {
+        border-left: 0px !important;
+    }
+
+    .ant-table-row-cell-last {
+        border-right: 0px !important;
+    }
+
+    .ant-pagination-prev, .ant-pagination-item, .ant-pagination-next {
+        color: #475447 !important
+    }
+
+    .md-theme-default a:not(.md-button) {
+        color: var(--md-theme-default-primary-on-background, #475447) !important
+    }
+
+    .ant-pagination-item-active, .ant-pagination-item-active:focus, .ant-pagination-item-active:hover, .ant-pagination-item:hover, .ant-pagination-item:focus {
+        border-color: #475447 !important;
+    }
+
+    .ant-pagination-next .ant-pagination-item-link, .ant-pagination-prev .ant-pagination-item-link {
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center
+    }
+
+    .ant-pagination.ant-table-pagination {
+        margin: 16px 0;
+        display: flex !important;
+        justify-content: center !important;
+        float: none !important;
+    }
+</style>

--- a/flint.ui/src/views/flint/TablePoint.vue
+++ b/flint.ui/src/views/flint/TablePoint.vue
@@ -1,168 +1,75 @@
 <template>
-<div>
-  <div class="relative bg-gradient-to-r from-green-400 to-blue-500 md:pt-32 pt-12 w-full h-full">
-    <div class="mx-auto w-full h-auto">
-      <div>
-        <div class="bg-white p-6 rounded-lg shadow-lg flex">
-          <h2 class="text-2xl font-bold text-gray-800 flex-1">Point example data visualisation table</h2>
-        </div>
-      </div>
+    <div class="w-full h-full">
+        <a-table :data-source="r" :columns="c"/>
     </div>
-    <div class="h-2/3 mt-12 px-6">
-      <v-grid style="height: 100%" theme="default" :source="rows" :columns="columns" :readonly="true"></v-grid>
-    </div>
-    <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
-  </div>
-  <PointOutput />
-  </div>
 </template>
-
 <script>
-/* eslint-disable */
-import VGrid from '@revolist/vue-datagrid'
-import PointOutput from './PointOutput.vue'
+    /* eslint-disable */
+    import Table from 'ant-design-vue'
 
-export default {
-  components: {
-    VGrid,
-    PointOutput
-  },
-  data() {
-    return {
-            myOptions: {
-        useKeyboardNavigation: true,
-        labels: {
-          buttonSkip: 'Skip tour',
-          buttonPrevious: 'Previous',
-          buttonNext: 'Next',
-          buttonStop: 'Finish'
-        }
-      },
-      steps: [
-        {
-          target: '[data-v-step="1"]',
-          content:
-            'Click on this button to visualize the table output in the graph.',
-          params: {
-            placement: 'left'
-          }
-        }
-      ],
-      columns: [
-        {
-          prop: 'point_step',
-          name: 'step',
-          size: 50
+    export default {
+        name: "TablePoint",
+        components: {
+            Table
         },
-        {
-          prop: 'point_stepDate',
-          name: 'stepDate',
-          size: 150
-        },
-        {
-          prop: 'point_stepLenInYears',
-          name: 'stepLenInYears',
-          size: 200
-        },
+        props: ['rows', 'columns'],
 
-        // stacked column
-        {
-        name: 'Pools',
-        children: [
-            {
-            prop: 'pool_1',
-            name: 'Pool 1',
-            size: 150
-          },
-          {
-            prop: 'pool_2',
-            name: 'Pool 2',
-            size: 150
-          },
-          {
-            prop: 'pool_3',
-            name: 'Pool 3',
-            size: 150
-          }
-        ],
+        data() {
+            return {
+                c: this.columns,
+                r: this.rows
+            }
         },
-      ],
-
-      rows: this.generateDataRows()
     }
-  },
-    mounted: function () {
-    this.$tours['MyTour'].start()
-  },
-  methods: {
-    pool_1() {
-      console.log('this.$store.state.point.pool_1')
-      console.log(this.$store.state.point.pool_1)
-      return this.$store.state.point.pool_1
-    },
-    pool_2() {
-      console.log('this.$store.state.point.pool_2')
-      console.log(this.$store.state.point.pool_2)
-      return this.$store.state.point.pool_2
-    },
-    pool_3() {
-      console.log('this.$store.state.point.pool_3')
-      console.log(this.$store.state.point.pool_3)
-      return this.$store.state.point.pool_3
-    },
-    point_step() {
-      console.log('this.$store.state.point.point_step')
-      console.log(this.$store.state.point.point_step)
-      return this.$store.state.point.point_step
-    },
-    point_stepDate() {
-      console.log('this.$store.state.point.point_stepDate')
-      console.log(this.$store.state.point.point_stepDate)
-      return this.$store.state.point.point_stepDate
-    },
-    point_stepLenInYears() {
-      console.log('this.$store.state.point.point_stepLenInYears')
-      console.log(this.$store.state.point.point_stepLenInYears)
-      return this.$store.state.point.point_stepLenInYears
-    },
-    generateDataRows: function () {
-      var result = []
-      var pool_1 = this.pool_1(),
-        pool_2 = this.pool_2(),
-        pool_3 = this.pool_3(),
-        point_step = this.point_step(),
-        point_stepDate = this.point_stepDate(),
-        point_stepLenInYears = this.point_stepLenInYears()
-      console.log('pool_1 from generateDataRows')
-      console.log(pool_1)
-      console.log('pool_2 from generateDataRows')
-      console.log(pool_2)
-      console.log('pool_3 from generateDataRows')
-      console.log(pool_3)
-      for (let j = 0; j < point_step.length; j++) {
-        let row = j
-        if (!result[row]) {
-          result[row] = {}
-        }
-        result[row]['point_step'] = point_step[row]
-        var defaultDateFormat = new Date(point_stepDate[row])
-        result[row]['point_stepDate'] = defaultDateFormat.toISOString().substring(0, 10);
-        result[row]['point_stepLenInYears'] = point_stepLenInYears[row].toPrecision(5)
-        result[row]['pool_1'] = pool_1[row].toPrecision(5)
-        result[row]['pool_2'] = pool_2[row].toPrecision(5)
-        result[row]['pool_3'] = pool_3[row].toPrecision(5)
-      }
-      console.log('result')
-      console.log(result)
-      return result
-    }
-  },
-  beforeCreate() {
-    this.$store.dispatch('parse_point_results')
-  },
-}
 </script>
 
 <style>
+    thead.ant-table-thead tr th {
+        color: white;
+        background-color: #475447;
+        border: 2px solid #EEEEF0;
+        text-align: center
+    }
 
+    .ant-table-row td {
+        border: 2px solid #EEEEF0;
+        text-align: center
+    }
+
+    .ant-table-thead > tr:first-child > th:first-child, .ant-table-row-cell-last {
+        border-radius: 0px !important;
+    }
+
+    .ant-table-thead > tr:first-child > th:first-child {
+        border-left: 0px !important;
+    }
+
+    .ant-table-row-cell-last {
+        border-right: 0px !important;
+    }
+
+    .ant-pagination-prev, .ant-pagination-item, .ant-pagination-next {
+        color: #475447 !important
+    }
+
+    .md-theme-default a:not(.md-button) {
+        color: var(--md-theme-default-primary-on-background, #475447) !important
+    }
+
+    .ant-pagination-item-active, .ant-pagination-item-active:focus, .ant-pagination-item-active:hover, .ant-pagination-item:hover, .ant-pagination-item:focus {
+        border-color: #475447 !important;
+    }
+
+    .ant-pagination-next .ant-pagination-item-link, .ant-pagination-prev .ant-pagination-item-link {
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center
+    }
+
+    .ant-pagination.ant-table-pagination {
+        margin: 16px 0;
+        display: flex !important;
+        justify-content: center !important;
+        float: none !important;
+    }
 </style>


### PR DESCRIPTION
## Description
Fixes #248 
Updated TablePoint.vue file to use Ant Design Tables.
Added PointOuterTable.vue file to allow switching between graph and table
Added Table and graph on configuration page itself as suggested in the Figma design.

## Testing
1. Explore the Point page from the homepage of flint-ui
2. Click on run to load the point data.
3. Click on the Point Output tabel to see Table and Graph.

If our automated tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look

![image](https://user-images.githubusercontent.com/55620053/166304253-ecd29e8d-7770-4d15-ab75-8b10f03a2aa9.png)
![image](https://user-images.githubusercontent.com/55620053/166304292-52242a8b-1f86-4edb-80a0-f21d88c2d6db.png)
I could also pass the props of row and column directly from the point page but it might be complex the information. Also, I can further modify it to make it complete reusable
