### PR TITLE
refactor: fixed navbar spacing bug

### DIFF
--- a/flint.ui/src/components/Navbars/LandingPageNavbar.vue
+++ b/flint.ui/src/components/Navbars/LandingPageNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="flex items-center justify-between flex-wrap px-24 py-4">
+  <nav class="flex items-center justify-between flex-wrap py-4 px-8 pb-6 sm:px-16 md:px-24">
     <div class="flex items-center flex-shrink-0 text-white">
       <router-link to="/" exact>
         <span class="font-semibold text-xl text-earth">


### PR DESCRIPTION
# Pull Request Template

## Description

The navbar spacing on the left and right now align properly with other contents on the pages. fixes #268 

## Testing

## Additional Context (Please include any Screenshots/gifs if relevant)
![FireShot Capture 019 - moja global FLINT UI - localhost](https://user-images.githubusercontent.com/63044364/167711246-0f3437fd-d391-4aa7-a285-45bd220d9e6c.png)

![FireShot Capture 020 - moja global FLINT UI - localhost](https://user-images.githubusercontent.com/63044364/167711256-8042f058-b9c3-4be1-91f9-7ffad8bab037.png)
