### PR TITLE
Updated Sphinx theme to Furo to match it with main documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme
+furo==2022.4.7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 furo==2022.4.7
+sphinx_rtd_theme


### PR DESCRIPTION
## Description

Updated the FLINT-UI documentation theme to Furo to match it with the main documentation of Moja Global. It Closes #274 

## Additional Context (Please include any Screenshots/gifs if relevant)
<img width="959" alt="image" src="https://user-images.githubusercontent.com/76848435/170776223-f3744510-6f54-4a60-bb1c-bea0dde8cca2.png">

...

<!--- Thanks for opening this pull request! --->
