### PR TITLE
docs+build: Replace Google Maps with OpenLayers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project provides an intuitive way for new to explore some preconfigured FLI
 - [Cypress](https://www.cypress.io/)
 - [Apexcharts](https://apexcharts.com/)
 - [Moment.js](https://momentjs.com/)
-- [Google Maps](https://developers.google.com/maps)
+- [OpenLayers](https://openlayers.org/)
 
 ## Getting started
 

--- a/flint.ui/package.json
+++ b/flint.ui/package.json
@@ -32,7 +32,6 @@
     "core-js": "^3.16.0",
     "data-forge": "^1.8.17",
     "fs": "0.0.1-security",
-    "google-maps": "4.3.3",
     "moment": "^2.29.1",
     "ol": "^6.6.1",
     "vue": "2.6.14",


### PR DESCRIPTION
## Description

Removes Google Maps as a dependency, since we don't use it anymore. Should skim off some of the `node_modules` bloat. Also replaces the mention of Google Maps with OpenLayers in README.

## Testing
N/A

## Additional Context (Please include any Screenshots/gifs if relevant)

N/A

<!--- Thanks for opening this pull request! --->
