### PR TITLE
fix: Make StepperGCBM immovable

### DIFF
--- a/flint.ui/src/components/Stepper/StepperGCBM.vue
+++ b/flint.ui/src/components/Stepper/StepperGCBM.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sticky bottom-0 z-50">
+  <div class="bottom-0 z-50">
     <md-steppers md-sync-route md-dynamic-height md-alternative class="large-screen">
       <md-step id="first" to="/gcbm/dashboard" md-label="New Simulation" />
 

--- a/flint.ui/yarn.lock
+++ b/flint.ui/yarn.lock
@@ -2849,11 +2849,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.39.1":
-  version "3.43.3"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.43.3.tgz#70cf962154a160fe78bcd69d6ccc296dd9175b1f"
-  integrity sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -7851,13 +7846,6 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
-
-google-maps@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/google-maps/-/google-maps-4.3.3.tgz#b8026723534e04713303f80853c32a1f1f6ed3cd"
-  integrity sha512-MQbEgBNQbGyV7mfS2tlFgW4EoGKLia24BvAl4a+kgsYWt4283kyPpaay/yKIsScQLr7nSUONaLNfOdMsCuJDEw==
-  dependencies:
-    "@types/googlemaps" "^3.39.1"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.9"


### PR DESCRIPTION
## Description

Removes `sticky` attribute to make the `StepperGCBM` component stay in place. Before, it would stick when scrolled. The changes are applied to `/gcbm/*`.

Fixes #286. 


## Testing

Head over to `/gcbm/dashboard` and try scrolling (Optionally zoom-in to make the component go out of view first).

## Additional Context
**Before:**

![image](https://user-images.githubusercontent.com/51860725/171387806-c1a05cb9-6821-4f5a-9c51-547995dbba60.png)

**After:**
![image](https://user-images.githubusercontent.com/51860725/171387716-e3349842-560d-42e4-917c-de0d368b3679.png)

<!--- Thanks for opening this pull request! --->
