### PR TITLE
fix+refactor: convert StepperGCBM to Ant Design

### DIFF
--- a/flint.ui/src/components/Footer/Footer.vue
+++ b/flint.ui/src/components/Footer/Footer.vue
@@ -140,6 +140,7 @@ export default {
 }
 .social-icons:hover {
   transform: scale(1.1);
+  background-color: white;
 }
 
 .social-icons .icon {

--- a/flint.ui/src/components/Stepper/StepperGCBM.vue
+++ b/flint.ui/src/components/Stepper/StepperGCBM.vue
@@ -1,30 +1,59 @@
 <template>
-  <div class="bottom-0 z-50">
-    <md-steppers md-sync-route md-dynamic-height md-alternative class="large-screen">
-      <md-step id="first" to="/gcbm/dashboard" md-label="New Simulation" />
-
-      <md-step id="second" to="/gcbm/upload" md-label="Upload dataset" />
-
-      <md-step id="third" to="/gcbm/run" md-label="Run | Status | Download" />
-    </md-steppers>
-
-    <md-steppers md-sync-route md-dynamic-height md-vertical class="small-screen">
-      <md-step id="first" to="/gcbm/dashboard" md-label="New Simulation" />
-
-      <md-step id="second" to="/gcbm/upload" md-label="Upload dataset" />
-
-      <md-step id="third" to="/gcbm/run" md-label="Run | Check Status | Download" />
-    </md-steppers>
+  <div class="stepper-container">
+	  <a-steps :current="current" @change="onChange">
+		<a-step title="New simulation"/>
+		<a-step title="Upload dataset"/>
+		<a-step title="Run | Status | Download"/>
+	  </a-steps>
   </div>
 </template>
 
 <script>
 export default {
-  methods: {}
-}
+  data() {
+	return {
+      current: 0,
+    };
+  },
+
+  mounted() {
+    this.current = this.$route.params.current
+  },
+
+  methods: {
+    onChange(current) {
+      this.current = current;
+
+     if (current == 0) {
+       this.$router.push({
+           name: "gcbmdashboard",
+           params: { current },
+       })
+     } else if (current == 1) {
+       this.$router.push({
+           name: "gcbmupload",
+           params: { current },
+       })
+     } else if (current == 2) {
+       this.$router.push({
+           name: "gcbmrun",
+           params: { current },
+       })
+     }
+    },
+  },
+};
 </script>
 
 <style scoped>
+.stepper-container {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	height: 100px;
+	padding: 40px;
+}
+
 .small-screen {
   display: block;
 }

--- a/flint.ui/src/routes/routes.js
+++ b/flint.ui/src/routes/routes.js
@@ -44,14 +44,17 @@ const routes = [
     component: GCBM,
     children: [
       {
+		name: 'gcbmdashboard',
         path: '/gcbm/dashboard',
         component: GCBMDashboard
       },
       {
+		name: 'gcbmupload',
         path: '/gcbm/upload',
         component: GCBMUpload
       },
       {
+		name: 'gcbmrun',
         path: '/gcbm/run',
         component: GCBMRun
       }

--- a/flint.ui/src/views/Landing.vue
+++ b/flint.ui/src/views/Landing.vue
@@ -26,7 +26,7 @@
     <a-row :gutter="[24, 48]" class="w-full py-14 md:py-20 px-8 sm:px-16 md:px-24 landing-cards">
       <LandingPageCard
         title="Point"
-        description="Point is a basic model int the FLINT that allows a person to enter three pool values, date, location. This is a good model to practice and a good starting point."
+        description="Point is a basic model in the FLINT that allows a person to enter three pool values, date, location. This is a good model to practice and a good starting point."
         link="/flint/configurations/point"
       />
       <LandingPageCard


### PR DESCRIPTION
## Description
This PR:
- Makes `StepperGCBM` based on Ant Design rather than Vue Material (We were having problems with Vue Material on Vue3).
- Fixes a bug where hovering over social media icons would result in a transparent background.
- Fixes a typo on the Landing page.

## Testing
- Visit `/gcbm/dashboard` and click on Step 1 or Step 3 (Step 2 is broken; see below).
- Hover over social icons in footer.

## Additional Context
![image](https://user-images.githubusercontent.com/51860725/171998851-122b0aea-71e6-430c-8d54-5485ff3f3c03.png)


**Note:** `GCBMUpload` is known to be broken (does not load) because we're using Vue2's Dropzone. Once we convert that to Vue3, we should be able to access it. Also, the stepper design can be refactored further to use icons and make it more responsive.
<!--- Thanks for opening this pull request! --->
