### PR TITLE
fix+refactor: Render Navbar and Footer in root component

### DIFF
--- a/flint.ui/src/App.vue
+++ b/flint.ui/src/App.vue
@@ -1,7 +1,17 @@
 <template>
+  <LandingPageNavbar />
   <router-view />
+  <FooterComponent />
 </template>
 
 <script>
-export default {}
+import LandingPageNavbar from './components/Navbars/LandingPageNavbar.vue'
+import FooterComponent from './components/Footer/Footer.vue'
+
+export default {
+  components: {
+    LandingPageNavbar,
+    FooterComponent
+  }
+}
 </script>

--- a/flint.ui/src/components/Stepper/StepperGCBM.vue
+++ b/flint.ui/src/components/Stepper/StepperGCBM.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="stepper-container">
-    <a-steps :current="current" @change="onChange">
+    <a-steps v-model:current="current" @change="onChange">
       <a-step title="New simulation" />
       <a-step title="Upload dataset" />
       <a-step title="Run | Status | Download" />
@@ -22,14 +22,8 @@ export default {
     }
   },
 
-  mounted() {
-    this.current = this.$route.params.current || this.initial
-  },
-
   methods: {
     onChange(current) {
-      this.current = current
-
       switch (current) {
         case 0:
           // New Simulation

--- a/flint.ui/src/views/Errorpage.vue
+++ b/flint.ui/src/views/Errorpage.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <LandingPageNavbar />
     <div class="flex-row pl-0 flex-wrap mt-6">
       <div class="p-6 innerdiv">
         <h1 class="mb mt-7 py-4 text-2xl text-earth my-4">Page Not Found</h1>
@@ -18,20 +17,15 @@
         </div>
       </div>
     </div>
-    <Footer />
   </div>
 </template>
 
 <script>
-import LandingPageNavbar from '../components/Navbars/LandingPageNavbar.vue'
-import Footer from '../components/Footer/Footer.vue'
 import Button from '../components/Button/Button.vue'
 
 export default {
   name: 'NotFound',
   components: {
-    LandingPageNavbar,
-    Footer,
     Button
   }
 }

--- a/flint.ui/src/views/Landing.vue
+++ b/flint.ui/src/views/Landing.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="parent">
-    <LandingPageNavbar />
     <div class="flex flex-row flex-wrap">
       <div class="relative flex content-center justify-center w-full min-h-screen-75 lg:w-5/12">
         <div
@@ -40,21 +39,16 @@
         link="/gcbm/dashboard"
       />
     </a-row>
-    <Footer />
   </div>
 </template>
 
 <script>
-import LandingPageNavbar from './../components/Navbars/LandingPageNavbar.vue'
 import LandingPageCard from './../components/Cards/LandingPageCard.vue'
-import Footer from './../components/Footer/Footer.vue'
 
 export default {
   name: 'Landing',
   components: {
-    LandingPageNavbar,
-    LandingPageCard,
-    Footer
+    LandingPageCard
   }
 }
 </script>

--- a/flint.ui/src/views/flint/ConfigurationsPoint.vue
+++ b/flint.ui/src/views/flint/ConfigurationsPoint.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <LandingPageNavbar />
     <div class="px-8 pb-6 sm:px-16 md:px-24">
       <div class="mt-14">
         <h2 class="text-xl sm:text-2xl md:text-2xl text-earth mb-3">Point example simulation configuration</h2>
@@ -95,26 +94,21 @@
       <v-tour name="MyTour" :steps="steps" :options="myOptions"></v-tour>
       <PointOuterTable v-if="showTable" />
     </div>
-    <Footer />
   </div>
 </template>
 
 <script>
 import Button from '@/components/Button/Button.vue'
 import Datepicker from '@/components/Datepicker/DatepickerPoint.vue'
-import LandingPageNavbar from '@/components/Navbars/LandingPageNavbar.vue'
 import Maptest from '@/components/Vuelayers/Maptest.vue'
 import Slider from '@/components/Slider/Slider.vue'
-import Footer from '@/components/Footer/Footer.vue'
 import PointOuterTable from './PointOuterTable.vue'
 
 export default {
   components: {
     Button,
     Datepicker,
-    LandingPageNavbar,
     Maptest,
-    Footer,
     Slider,
     PointOuterTable
   },

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <div class="mb-10 mx-5 md:justify-center">
-      <LandingPageNavbar />
       <div class="px-8 pb-6 sm:px-16 md:px-24">
         <div>
           <h2 class="mb mt-7 py-4 text-2xl text-earth">RothC example simulation configuration</h2>
@@ -53,16 +52,13 @@
         <RothCOuterTable v-if="showTable" />
       </div>
     </div>
-    <Footer />
   </div>
 </template>
 
 <script>
 import RothCTemplate from '@/views/flint/RothCTemplate.vue'
 import Datepicker from '@/components/Datepicker/DatepickerRothC.vue'
-import LandingPageNavbar from '../../components/Navbars/LandingPageNavbar.vue'
 import Button from '@/components/Button/Button.vue'
-import Footer from '@/components/Footer/Footer.vue'
 import RothCOuterTable from './RothCOuterTable.vue'
 import RothCAvgAirTempVue from '@/components/ConfigurationsRothC/RothCAvgAirTemp.vue'
 import RothCSoilCoverVue from '@/components/ConfigurationsRothC/RothCSoilCover.vue'
@@ -79,11 +75,9 @@ export default {
   components: {
     RothCTemplate,
     Datepicker,
-    LandingPageNavbar,
     RightOutlined,
     RothCOuterTable,
-    Button,
-    Footer
+    Button
   },
   data: function () {
     return {

--- a/flint.ui/src/views/gcbm/GCBMDashboard.vue
+++ b/flint.ui/src/views/gcbm/GCBMDashboard.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <LandingPageNavbar />
     <div class="px-8 pb-6 sm:px-16 md:px-24 mt-8">
       <div class="bg-white p-6 rounded-lg shadow-lg">
         <h2 class="mt-3 text-2xl font-bold mb-2 text-gray-800">GCBM simulation workflow</h2>
@@ -62,23 +61,18 @@
       </div>
     </div>
     <StepperGCBM :initial="0" />
-    <FooterComponent />
   </div>
 </template>
 
 <script>
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
-import LandingPageNavbar from '@/components/Navbars/LandingPageNavbar.vue'
-import FooterComponent from '@/components/Footer/Footer.vue'
 
 export default {
   name: 'DashboardPage',
   components: {
     StepperGCBM,
-    StepperStatic,
-    LandingPageNavbar,
-    FooterComponent
+    StepperStatic
   },
 
   data: () => ({

--- a/flint.ui/src/views/gcbm/GCBMRun.vue
+++ b/flint.ui/src/views/gcbm/GCBMRun.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <LandingPageNavbar />
     <div class="px-8 pb-6 sm:px-16 md:px-24 mt-8">
       <div class="bg-white p-6 rounded-lg shadow-lg">
         <h2 class="mt-3 text-2xl font-bold mb-2 text-gray-800">GCBM simulation workflow</h2>
@@ -85,27 +84,22 @@
     </div>
 
     <StepperGCBM :initial="2" />
-    <FooterComponent />
   </div>
 </template>
 
 <script>
-import LandingPageNavbar from '../../components/Navbars/LandingPageNavbar.vue'
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import Toggle from '@/components/Slider/Toggle.vue'
-import FooterComponent from '@/components/Footer/Footer.vue'
 import axios from 'axios'
 import { useToast } from 'vue-toastification'
 
 export default {
   name: 'DashboardPage',
   components: {
-    LandingPageNavbar,
-    StepperGCBM,
-    StepperStatic,
     Toggle,
-    FooterComponent
+    StepperGCBM,
+    StepperStatic
   },
 
   data: () => ({

--- a/flint.ui/src/views/gcbm/GCBMUpload.vue
+++ b/flint.ui/src/views/gcbm/GCBMUpload.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <LandingPageNavbar />
     <div class="px-8 pb-6 md:px-24 mt-8">
       <div class="bg-white p-6 rounded-lg shadow-lg flex flex-wrap justify-between">
         <h2 class="mt-3 text-2xl font-bold mb-2 text-gray-800">GCBM simulation workflow</h2>
@@ -68,27 +67,22 @@
     </div>
 
     <StepperGCBM :initial="1" />
-    <FooterComponent />
   </div>
 </template>
 
 <script>
-import LandingPageNavbar from '../../components/Navbars/LandingPageNavbar.vue'
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import FileUpload from '@/components/FileUpload/FileUpload.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
-import FooterComponent from '@/components/Footer/Footer.vue'
 import axios from 'axios'
 import { useToast } from 'vue-toastification'
 
 export default {
   name: 'DashboardPage',
   components: {
-    LandingPageNavbar,
     StepperGCBM,
     FileUpload,
-    StepperStatic,
-    FooterComponent
+    StepperStatic
   },
 
   data: () => ({


### PR DESCRIPTION
## Description

1. Until now, we were rendering the `Footer` and `LandingPageNavbar` components in every component. These can be moved to the root component `App` to eliminate redundancy. 

2. A very minor bug existed in `StepperGCBM` which would cause the currently selected step to appear hollow. This PR fixes the bug. Now the step is correctly highlighted with a blue color.

## Testing
For the bug fix: go to `/gcbm/dashboard` and click on any of the steps.

## Additional Context
![image](https://user-images.githubusercontent.com/51860725/172225879-922883cc-2d1b-4c75-baa7-ed6668332ceb.png)

<!--- Thanks for opening this pull request! --->
