### PR TITLE
refactor: Migrate from Fontawesome to AntD icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ This project provides an intuitive way for new to explore some preconfigured FLI
 
 - [Vue.js](https://vuejs.org/)
 - [Ant Design Vue ](https://antdv.com/)
-- [Fontawesome](https://fontawesome.com/)
 - [TailwindCSS](https://tailwindcss.com/)
 - [Cypress](https://www.cypress.io/)
 - [Apexcharts](https://apexcharts.com/)

--- a/flint.ui/package.json
+++ b/flint.ui/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@ant-design/icons-vue": "^6.1.0",
-    "@fortawesome/fontawesome-free": "5.15.4",
     "@popperjs/core": "2.9.3",
     "@stencil/core": "^2.15.0",
     "@tailwindcss/forms": "0.3.3",

--- a/flint.ui/src/components/Cards/CardInfoRun.vue
+++ b/flint.ui/src/components/Cards/CardInfoRun.vue
@@ -28,7 +28,7 @@
             "
             @click="showConfirmRunModal()"
           >
-            <i class="far fa-play-circle" /> {{ cardFunctionRun }}
+            <PlayCircleOutlined /> {{ cardFunctionRun }}
           </button>
 
           <confirm-run
@@ -50,11 +50,13 @@ import axios from 'axios'
 import { ref } from 'vue'
 import ConfirmRun from '@/components/Prompts/ConfirmRun'
 import { useToast } from 'vue-toastification'
+import { PlayCircleOutlined } from '@ant-design/icons-vue'
 
 export default {
   name: 'CardInfoRun',
   components: {
-    ConfirmRun
+    ConfirmRun,
+    PlayCircleOutlined
   },
   props: {
     cardSubtitle: {

--- a/flint.ui/src/components/Footer/Footer.vue
+++ b/flint.ui/src/components/Footer/Footer.vue
@@ -8,13 +8,13 @@
       <a-col :xs="24" :md="5">
         <h2 class="title">Get In Touch</h2>
         <div class="email">
-          <i class="fas fa-envelope" />
-          <a href="mailto:info@moja.global"> info@moja.global</a>
+          <MailFilled :style="{color: '#ffffff', fontSize: '17px'}"/>
+          <a class="ml-1" href="mailto:info@moja.global"> info@moja.global</a>
         </div>
 
-        <div class="socials">
+        <div class="mt-5 socials">
           <a-button type="text" shape="circle" href="https://twitter.com/mojaglobal" class="social-icons">
-            <i class="fab fa-twitter fa-2x icon"></i>
+            <TwitterCircleFilled :style="{fontSize: '28px'}" />
           </a-button>
 
           <a-button
@@ -23,7 +23,7 @@
             href="https://www.linkedin.com/company/moja-global/"
             class="social-icons"
           >
-            <i class="fab fa-linkedin fa-2x icon"></i>
+            <LinkedinFilled :style="{fontSize: '28px'}" />
           </a-button>
         </div>
       </a-col>
@@ -85,8 +85,11 @@
 </template>
 
 <script>
+import { TwitterCircleFilled, LinkedinFilled, MailFilled } from '@ant-design/icons-vue'
+
 export default {
-  name: 'FooterComponent'
+  name: 'FooterComponent',
+  components: {TwitterCircleFilled, LinkedinFilled, MailFilled}
 }
 </script>
 

--- a/flint.ui/src/components/Stepper/StepperStatic.vue
+++ b/flint.ui/src/components/Stepper/StepperStatic.vue
@@ -9,14 +9,15 @@
             :xl="{ span: 20 }"
             class="bg-gray-300 border border-gray-200 card-content rounded-lg"
           >
-            <i class="fas fa-plus fa-lg" />
+            <PlusOutlined :style="{fontSize: '24px',marginLeft: '5px'}"/>
             <div class="bg-gray-200 rounded-r-lg body-step">
               <h2 class="font-bold text-sm">Create a new simulation</h2>
               <p class="text-xs text-gray-600">Click the new button below</p>
             </div>
           </a-col>
           <a-col class="next-icons" :xs="{ span: 24 }" :md="{ span: 4 }" :xl="{ span: 4 }">
-            <i class="fas fa-arrow-right fa-2x" />
+            <ArrowRightOutlined :style="{fontSize: '24px'}" />
+
           </a-col>
         </a-row>
       </a-col>
@@ -29,14 +30,14 @@
             :xl="{ span: 20 }"
             class="bg-gray-300 border border-gray-200 card-content rounded-lg"
           >
-            <i class="fas fa-file fa-lg" />
+            <FileFilled :style="{fontSize: '24px', marginLeft: '5px'}"/>
             <div class="bg-gray-200 rounded-r-lg body-step">
               <h2 class="font-bold text-sm">Upload file</h2>
               <p class="text-xs text-gray-600">Dataset file for GCBM</p>
             </div>
           </a-col>
           <a-col class="next-icons" :xs="{ span: 24 }" :md="{ span: 4 }" :xl="{ span: 4 }">
-            <i class="fas fa-arrow-right fa-2x" />
+            <ArrowRightOutlined :style="{fontSize: '24px'}" />
           </a-col>
         </a-row>
       </a-col>
@@ -49,14 +50,14 @@
             :xl="{ span: 20 }"
             class="bg-gray-300 border border-gray-200 card-content rounded-lg"
           >
-            <i class="fas fa-cogs fa-lg" />
+            <SettingFilled :style="{fontSize: '24px', marginLeft: '5px'}"/>
             <div class="bg-gray-200 rounded-r-lg body-step">
               <h2 class="font-bold text-sm">Configure</h2>
               <p class="text-xs text-gray-600">Change configuration parameters</p>
             </div>
           </a-col>
           <a-col class="next-icons" :xs="{ span: 24 }" :md="{ span: 4 }" :xl="{ span: 4 }">
-            <i class="fas fa-arrow-right fa-2x" />
+            <ArrowRightOutlined :style="{fontSize: '24px'}" />
           </a-col>
         </a-row>
       </a-col>
@@ -69,7 +70,7 @@
             :xl="{ span: 20 }"
             class="bg-gray-300 border border-gray-200 card-content rounded-lg"
           >
-            <i class="fas fa-check fa-lg" />
+            <CheckOutlined :style="{fontSize: '24px', marginLeft: '5px'}" />
             <div class="bg-gray-200 rounded-r-lg body-step">
               <h2 class="font-bold text-sm">Run</h2>
               <p class="text-xs text-gray-600">Run the simulation with new configs</p>
@@ -83,8 +84,18 @@
 </template>
 
 <script>
+import { PlusOutlined, FileFilled, SettingFilled, CheckOutlined, ArrowRightOutlined  } from '@ant-design/icons-vue'
+
+
 export default {
-  name: 'StepperStatic'
+  name: 'StepperStatic',
+  components: {
+    PlusOutlined,
+    FileFilled,
+    SettingFilled,
+    CheckOutlined,
+    ArrowRightOutlined
+  }
 }
 </script>
 

--- a/flint.ui/src/main.js
+++ b/flint.ui/src/main.js
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 
 import App from './App.vue'
-import '@fortawesome/fontawesome-free/css/all.min.css'
 import './index.css'
 
 import { store } from './store'

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -35,7 +35,7 @@
             :show-arrow="false"
           >
             <template #extra>
-              <i class="far fa-angle-right" :rotate="accordionActiveKey == index ? 90 : 0" />
+			        <RightOutlined :rotate="accordionActiveKey == index ? 90 : 0"/>
             </template>
             <component :is="item.component" />
           </a-collapse-panel>

--- a/flint.ui/src/views/flint/RothCTemplate.vue
+++ b/flint.ui/src/views/flint/RothCTemplate.vue
@@ -26,7 +26,7 @@
               "
               @click="ConfigData"
             >
-              <i class="far fa-edit" /> {{ configDataexample }}
+              <FormOutlined /> {{ configDataexample }}
             </button>
           </div>
         </div>
@@ -36,9 +36,12 @@
 </template>
 
 <script>
+import { FormOutlined } from '@ant-design/icons-vue'
+
+
 export default {
   name: 'CardRothConfig',
-  components: {},
+  components: {FormOutlined},
   props: {
     configParamtext: {
       type: String,

--- a/flint.ui/src/views/gcbm/GCBMDashboard.vue
+++ b/flint.ui/src/views/gcbm/GCBMDashboard.vue
@@ -35,9 +35,8 @@
               class="
                 w-full
                 mt-4
-                block
-                align-middle
-                flex-initial
+                inline-flex
+                items-center
                 bg-white
                 hover:bg-earth hover:text-white
                 text-gray-800
@@ -52,7 +51,7 @@
               :class="{ 'opacity-25 cursor-not-allowed': isTitle() }"
               @click="sendToAPI"
             >
-              <i class="fas fa-plus" /> Create run
+              <PlusOutlined :style="{marginRight: '16px'}" /> Create run
             </button>
           </div>
 
@@ -67,12 +66,14 @@
 <script>
 import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
+import { PlusOutlined } from '@ant-design/icons-vue'
 
 export default {
   name: 'DashboardPage',
   components: {
     StepperGCBM,
-    StepperStatic
+    StepperStatic,
+    PlusOutlined
   },
 
   data: () => ({

--- a/flint.ui/src/views/gcbm/GCBMRun.vue
+++ b/flint.ui/src/views/gcbm/GCBMRun.vue
@@ -38,7 +38,8 @@
                   "
                   @click="runSim"
                 >
-                  <i class="far fa-play-circle"></i> Run simulation
+                  <PlayCircleOutlined /> 
+                  <p>Run simulation </p>
                 </button>
               </a-col>
 
@@ -56,7 +57,8 @@
                   "
                   @click="checkStatus"
                 >
-                  <i class="fas fa-question"></i> Check status
+                  <QuestionCircleOutlined :style="{fontSize: '16px'}" /> 
+                  <p>Check status</p>
                 </button>
               </a-col>
 
@@ -74,7 +76,8 @@
                   "
                   @click="downloadSim"
                 >
-                  <i class="fas fa-download"></i> Download simulation
+                  <DownloadOutlined /> 
+                  <p>Download simulation </p>
                 </button>
               </a-col>
             </a-row>
@@ -93,13 +96,17 @@ import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import Toggle from '@/components/Slider/Toggle.vue'
 import axios from 'axios'
 import { useToast } from 'vue-toastification'
+import { PlayCircleOutlined, QuestionCircleOutlined, DownloadOutlined  } from '@ant-design/icons-vue'
 
 export default {
   name: 'DashboardPage',
   components: {
     Toggle,
     StepperGCBM,
-    StepperStatic
+    StepperStatic,
+    PlayCircleOutlined,
+    QuestionCircleOutlined,
+    DownloadOutlined
   },
 
   data: () => ({

--- a/flint.ui/src/views/gcbm/GCBMUpload.vue
+++ b/flint.ui/src/views/gcbm/GCBMUpload.vue
@@ -6,9 +6,8 @@
 
         <button
           class="
-            inline-block
-            align-middle
-            flex-initial
+            inline-flex
+            items-center
             bg-white
             hover:bg-earth hover:text-white
             text-gray-800
@@ -21,7 +20,7 @@
           "
           @click="hello"
         >
-          <i class="far fa-file" /> Submit uploaded files
+          <FileOutlined :style="{marginRight: '4px'}"/> Submit uploaded files
         </button>
       </div>
 
@@ -76,13 +75,15 @@ import FileUpload from '@/components/FileUpload/FileUpload.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import axios from 'axios'
 import { useToast } from 'vue-toastification'
+import { FileOutlined } from '@ant-design/icons-vue'
 
 export default {
   name: 'DashboardPage',
   components: {
     StepperGCBM,
     FileUpload,
-    StepperStatic
+    StepperStatic,
+    FileOutlined
   },
 
   data: () => ({

--- a/flint.ui/yarn.lock
+++ b/flint.ui/yarn.lock
@@ -1284,11 +1284,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-free@5.15.4":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
-  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
## Description

This PR converts all FontAwesome icons to Ant Design icons. This way, we can get rid of the dependency entirely. The icons also fit better with the rest of the components oriented towards Ant Design. Most of the icons are the exact same, while some of them resemble the previous icons as closely as possible.

It also fixes the bug where `RothC` accordion arrows were not rendered properly. Now they work and rotate as intended. 

## Testing

Visit various endpoints throughout the web application to see the new icons on the components.

## Additional Context 
Icons that have been converted:
- `fa-play-circle` --> `PlayCircleOutlined`
- `fa-envelope` --> `MailFilled`
- `fa-twitter` --> `TwitterCircleFilled`
- `fa-linkedin` --> `LinkedinFilled`
- `fa-plus` --> `PlusOutlined`
- `fa-arrow-right` --> `ArrowRightOutlined`
- `fa-file` --> `FileFilled`
- `fa-cogs` --> `SettingFilled`
- `fa-check` --> `CheckOutlined`
- `fa-edit` --> `FormOutlined`
- `fa-question` --> `QuestionCircleOutlined`
- `fa-download` --> `DownloadOutlined`

<!--- Thanks for opening this pull request! --->
