### PR TITLE
refactor: Migrate from Toasts to Notifications

### DIFF
--- a/flint.ui/package.json
+++ b/flint.ui/package.json
@@ -37,7 +37,6 @@
     "vue-clickaway": "2.2.2",
     "vue-github-buttons": "3.1.0",
     "vue-router": "^4.0.15",
-    "vue-toastification": "^2.0.0-rc.5",
     "vue3-apexcharts": "^1.4.1",
     "vue3-dropzone": "^0.0.7",
     "vue3-openlayers": "^0.1.67",

--- a/flint.ui/src/components/Cards/CardInfoRun.vue
+++ b/flint.ui/src/components/Cards/CardInfoRun.vue
@@ -49,8 +49,8 @@
 import axios from 'axios'
 import { ref } from 'vue'
 import ConfirmRun from '@/components/Prompts/ConfirmRun'
-import { useToast } from 'vue-toastification'
 import { PlayCircleOutlined } from '@ant-design/icons-vue'
+import { notification } from 'ant-design-vue'
 
 export default {
   name: 'CardInfoRun',
@@ -82,8 +82,7 @@ export default {
   },
   setup() {
     const isConfirmRunModalVisible = ref(false)
-    const toast = useToast()
-
+    
     function showConfirmRunModal() {
       isConfirmRunModalVisible.value = true
     }
@@ -113,13 +112,17 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/spec`)
         .then((response) => {
-          toast.success(`Specification route has been invoked.`, {
-            timeout: 2000
+          notification['success']({
+            message: 'Specification route has been invoked',
+            duration: 2
           })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }
@@ -129,13 +132,17 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/help/all`)
         .then((response) => {
-          toast.success(`Help route has been invoked.`, {
-            timeout: 2000
+          notification['success']({
+            message: 'Help route has been invoked',
+            duration: 2
           })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }
@@ -145,13 +152,17 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/version`)
         .then((response) => {
-          toast.success(`Version route has been invoked.`, {
-            timeout: 2000
+          notification['success']({
+            message: 'Version route has been invoked',
+            duration: 2
           })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }
@@ -161,13 +172,17 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/point`)
         .then((response) => {
-          toast.success(`Point route has been invoked. You can see the output in Point Output Table.`, {
-            timeout: 2000
+          notification['success']({
+            message: 'Point route has been invoked',
+            duration: 2
           })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }
@@ -177,19 +192,26 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/rothc`)
         .then((response) => {
-          toast.success(`RothC route has been invoked. You can see the output in RothC Output Table.`, {
-            timeout: 2000
+          notification['success']({
+            message: 'RothC route has been invoked. You can see the output in RothC Output Table.',
+            duration: 2
           })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }
 
     function apiRoute_nonexistent() {
-      toast.warning('No such route exists!', { timeout: 2000 })
+      notification['warning']({
+        message: 'No such route exists!',
+        duration: 4
+      })
       console.log('No such route exists!')
     }
 

--- a/flint.ui/src/components/Cards/CardInfoRun.vue
+++ b/flint.ui/src/components/Cards/CardInfoRun.vue
@@ -82,7 +82,6 @@ export default {
   },
   setup() {
     const isConfirmRunModalVisible = ref(false)
-    
     function showConfirmRunModal() {
       isConfirmRunModalVisible.value = true
     }
@@ -112,16 +111,16 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/spec`)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: 'Specification route has been invoked',
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -132,16 +131,16 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/help/all`)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: 'Help route has been invoked',
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -152,16 +151,16 @@ export default {
       axios
         .get(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/version`)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: 'Version route has been invoked',
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -172,16 +171,16 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/point`)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: 'Point route has been invoked',
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -192,25 +191,25 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/rothc`)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: 'RothC route has been invoked. You can see the output in RothC Output Table.',
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
     }
 
     function apiRoute_nonexistent() {
-      notification['warning']({
+      notification.warning({
         message: 'No such route exists!',
-        duration: 4
+        duration: 5
       })
       console.log('No such route exists!')
     }

--- a/flint.ui/src/components/Datepicker/DatepickerPoint.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerPoint.vue
@@ -37,7 +37,7 @@
 <script>
 import dayjs from 'dayjs'
 import { ref, computed } from 'vue'
-import { useToast } from 'vue-toastification'
+import { notification } from 'ant-design-vue'
 
 export default {
   props: {
@@ -71,8 +71,9 @@ export default {
         console.log(selectedStartDate.value)
 
         if (date_diff.value < 0) {
-          toast.error('Start date should be less than end date', {
-            timeout: 5000
+          notification['error']({
+            message: "Start date should be less than end date",
+            duration: 4
           })
         }
       }
@@ -88,8 +89,9 @@ export default {
         console.log(selectedEndDate.value)
 
         if (date_diff.value < 0) {
-          toast.error('End date should be greater than start date', {
-            timeout: 5000
+          notification['error']({
+            message: "End date shuold be greater than start date ",
+            duration: 4
           })
         }
       }

--- a/flint.ui/src/components/Datepicker/DatepickerPoint.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerPoint.vue
@@ -45,7 +45,6 @@ export default {
   },
   setup(props, { emit }) {
     const dateFormatList = ['DD/MM/YYYY', 'DD/MM/YY']
-    const toast = useToast()
     const selectedStartDate = ref(props.value)
     const selectedEndDate = ref(props.value)
 
@@ -71,9 +70,9 @@ export default {
         console.log(selectedStartDate.value)
 
         if (date_diff.value < 0) {
-          notification['error']({
-            message: "Start date should be less than end date",
-            duration: 4
+          notification.error({
+            message: 'Start date should be lesser than end date',
+            duration: 5
           })
         }
       }
@@ -89,9 +88,9 @@ export default {
         console.log(selectedEndDate.value)
 
         if (date_diff.value < 0) {
-          notification['error']({
-            message: "End date shuold be greater than start date ",
-            duration: 4
+          notification.error({
+            message: 'End date should be greater than start date.',
+            duration: 5
           })
         }
       }

--- a/flint.ui/src/components/Datepicker/DatepickerRothC.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerRothC.vue
@@ -45,7 +45,6 @@ export default {
   },
   setup(props, { emit }) {
     const dateFormatList = ['DD/MM/YYYY', 'DD/MM/YY']
-    const toast = useToast()
     const selectedStartDate = ref(props.value)
     const selectedEndDate = ref(props.value)
 
@@ -71,9 +70,9 @@ export default {
         console.log(selectedStartDate.value)
 
         if (date_diff.value < 0) {
-          notification['error']({
+          notification.error({
             message: 'Start date should be lesser than end date',
-            duration : 4
+            duration: 5
           })
         }
       }
@@ -89,9 +88,9 @@ export default {
         console.log(selectedEndDate.value)
 
         if (date_diff.value < 0) {
-          notification['error']({
+          notification.error({
             message: 'End date should be greater than start date',
-            duration : 4
+            duration: 5
           })
         }
       }

--- a/flint.ui/src/components/Datepicker/DatepickerRothC.vue
+++ b/flint.ui/src/components/Datepicker/DatepickerRothC.vue
@@ -37,7 +37,7 @@
 <script>
 import dayjs from 'dayjs'
 import { ref, computed } from 'vue'
-import { useToast } from 'vue-toastification'
+import { notification } from 'ant-design-vue'
 
 export default {
   props: {
@@ -71,8 +71,9 @@ export default {
         console.log(selectedStartDate.value)
 
         if (date_diff.value < 0) {
-          toast.error('Start date should be less than end date', {
-            timeout: 5000
+          notification['error']({
+            message: 'Start date should be lesser than end date',
+            duration : 4
           })
         }
       }
@@ -88,8 +89,9 @@ export default {
         console.log(selectedEndDate.value)
 
         if (date_diff.value < 0) {
-          toast.error('End date should be greater than start date', {
-            timeout: 5000
+          notification['error']({
+            message: 'End date should be greater than start date',
+            duration : 4
           })
         }
       }

--- a/flint.ui/src/components/FileUpload/FileUpload.vue
+++ b/flint.ui/src/components/FileUpload/FileUpload.vue
@@ -163,9 +163,9 @@ export default {
       console.log(this.$refs.myVueDropzoneInput.getAcceptedFiles())
 
       if (store.state.gcbm.DropdownSelectedSim == '') {
-        notification['error']({
+        notification.error({
           message: 'Title cannot be empty, Select a valid simulation title from the dropdown',
-          duration : 4
+          duration: 5
         })
       } else {
         this.add_title_to_formdata()
@@ -174,17 +174,17 @@ export default {
         axios
           .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/upload`, this.formData)
           .then((response) => {
-            notification['success']({
+            notification.success({
               message: `${response.data.data}`,
-              duration : 2
+              duration: 5
             })
             console.log(response)
             console.log(response.data)
           })
           .catch((error) => {
-            notification['error']({
+            notification.error({
               message: `${error}`,
-              duration : 4
+              duration: 5
             })
             console.log(error)
           })

--- a/flint.ui/src/components/FileUpload/FileUpload.vue
+++ b/flint.ui/src/components/FileUpload/FileUpload.vue
@@ -93,11 +93,9 @@
 <script>
 import { ref } from 'vue'
 import { useDropzone } from 'vue3-dropzone'
-
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
 import { useStore } from 'vuex'
-
+import { notification } from 'ant-design-vue'
 export default {
   setup() {
     const store = useStore()
@@ -163,10 +161,12 @@ export default {
       console.log(this.$refs.myVueDropzoneDB.getAcceptedFiles())
       console.log('list of input files')
       console.log(this.$refs.myVueDropzoneInput.getAcceptedFiles())
-      const toast = useToast()
 
       if (store.state.gcbm.DropdownSelectedSim == '') {
-        toast.error('Title cannot be empty, Select a valid simulation title from the dropdown', { timeout: 5000 })
+        notification['error']({
+          message: 'Title cannot be empty, Select a valid simulation title from the dropdown',
+          duration : 4
+        })
       } else {
         this.add_title_to_formdata()
         console.log([...this.formData])
@@ -174,12 +174,18 @@ export default {
         axios
           .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/upload`, this.formData)
           .then((response) => {
-            toast.success(`${response.data.data}`, { timeout: 3000 })
+            notification['success']({
+              message: `${response.data.data}`,
+              duration : 2
+            })
             console.log(response)
             console.log(response.data)
           })
           .catch((error) => {
-            toast.error(`${error}`, { timeout: 2000 })
+            notification['error']({
+              message: `${error}`,
+              duration : 4
+            })
             console.log(error)
           })
       }

--- a/flint.ui/src/main.js
+++ b/flint.ui/src/main.js
@@ -7,9 +7,6 @@ import './index.css'
 import { store } from './store'
 import routes from './routes/routes'
 
-import Toast from 'vue-toastification'
-import 'vue-toastification/dist/index.css'
-
 import OpenLayersMap from 'vue3-openlayers'
 import 'vue3-openlayers/dist/vue3-openlayers.css'
 
@@ -28,7 +25,6 @@ const router = createRouter({
 })
 
 const app = createApp(App)
-app.use(Toast)
 app.use(Antd)
 app.use(store)
 app.use(router)

--- a/flint.ui/src/store/modules/gcbm.js
+++ b/flint.ui/src/store/modules/gcbm.js
@@ -664,29 +664,28 @@ export default {
       bodyFormData.append('title', this.state.gcbm.config.title)
       console.log([...bodyFormData])
 
-
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/new`, bodyFormData)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: `${response.data.data}`,
-            duration: 4
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
     },
     check_gcbm_run_status() {
       axios.get(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/list`).then((response) => {
-        notification['success']({
+        notification.success({
           message: `${response.data.data}`,
-          duration: 4
+          duration: 5
         })
         console.log(response.data)
       })

--- a/flint.ui/src/store/modules/gcbm.js
+++ b/flint.ui/src/store/modules/gcbm.js
@@ -1,5 +1,5 @@
+import { notification } from 'ant-design-vue'
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
 
 export default {
   state: {
@@ -664,24 +664,30 @@ export default {
       bodyFormData.append('title', this.state.gcbm.config.title)
       console.log([...bodyFormData])
 
-      const toast = useToast()
 
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/new`, bodyFormData)
         .then((response) => {
-          toast.success(`${response.data.data}`, { timeout: 5000 })
+          notification['success']({
+            message: `${response.data.data}`,
+            duration: 4
+          })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     },
     check_gcbm_run_status() {
-      const toast = useToast()
-
       axios.get(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/list`).then((response) => {
-        toast.success(`${response.data.data}`, { timeout: 5000 })
+        notification['success']({
+          message: `${response.data.data}`,
+          duration: 4
+        })
         console.log(response.data)
       })
     }

--- a/flint.ui/src/store/modules/point.js
+++ b/flint.ui/src/store/modules/point.js
@@ -230,18 +230,18 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/point`, final_config_string)
         .then((response) => {
-          notification['success']({
-            message: "Configuration loaded for Point.",
-            duration: 2
+          notification.success({
+            message: 'Configuration loaded for Point.',
+            duration: 5
           })
           console.log(response)
           commit('save_point_results', response.data)
           console.log(this.state.point.point_results)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })

--- a/flint.ui/src/store/modules/point.js
+++ b/flint.ui/src/store/modules/point.js
@@ -1,5 +1,5 @@
+import { notification } from 'ant-design-vue'
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
 
 export default {
   state: {
@@ -227,19 +227,22 @@ export default {
       let config_string = JSON.stringify(this.state.point.config)
       let parsed_config_string = config_string.replaceAll('"#$', ' ')
       let final_config_string = parsed_config_string.replaceAll('#$"', ' ')
-      const toast = useToast()
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/point`, final_config_string)
         .then((response) => {
-          toast.success(`Configuration loaded for Point.`, {
-            timeout: 2000
+          notification['success']({
+            message: "Configuration loaded for Point.",
+            duration: 2
           })
           console.log(response)
           commit('save_point_results', response.data)
           console.log(this.state.point.point_results)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
       commit('updateFlag', 1)

--- a/flint.ui/src/store/modules/rothc.js
+++ b/flint.ui/src/store/modules/rothc.js
@@ -485,22 +485,21 @@ export default {
 
       console.log(final_RothC_config_string)
 
-
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/rothc`, final_RothC_config_string)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: `Configuration loaded for RothC.`,
-            duration: 2
+            duration: 5
           })
 
           commit('save_rothc_results', response.data)
           console.log(this.state.rothc.rothc_results)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })

--- a/flint.ui/src/store/modules/rothc.js
+++ b/flint.ui/src/store/modules/rothc.js
@@ -1,5 +1,5 @@
+import { notification } from 'ant-design-vue'
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
 
 export default {
   state: {
@@ -485,19 +485,23 @@ export default {
 
       console.log(final_RothC_config_string)
 
-      const toast = useToast()
 
       axios
         .post(`${process.env.VUE_APP_REST_API_FLINT_EXAMPLE}/rothc`, final_RothC_config_string)
         .then((response) => {
-          toast.success(`Configuration loaded for RothC.`, {
-            timeout: 2000
+          notification['success']({
+            message: `Configuration loaded for RothC.`,
+            duration: 2
           })
+
           commit('save_rothc_results', response.data)
           console.log(this.state.rothc.rothc_results)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     },

--- a/flint.ui/src/views/gcbm/GCBMRun.vue
+++ b/flint.ui/src/views/gcbm/GCBMRun.vue
@@ -95,7 +95,7 @@ import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import Toggle from '@/components/Slider/Toggle.vue'
 import axios from 'axios'
-import { PlayCircleOutlined, QuestionCircleOutlined, DownloadOutlined  } from '@ant-design/icons-vue'
+import { PlayCircleOutlined, QuestionCircleOutlined, DownloadOutlined } from '@ant-design/icons-vue'
 import { notification } from 'ant-design-vue'
 
 export default {
@@ -123,16 +123,16 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/dynamic`, bodyFormData)
         .then((response) => {
-          notification['success']({
+          notification.success({
             message: response.data.status,
-            duration: 2
+            duration: 5
           })
           console.log(response)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -147,18 +147,18 @@ export default {
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/status`, bodyFormData)
         .then((response) => {
-          notification['info']({
+          notification.info({
             message: `${response.data.finished}`,
-            duration: 2
+            duration: 5
           })
           this.$store.commit('setSimulationProgressState', response.data.finished)
           console.log(response)
           console.log(this.$store.state.gcbm.SimulationProgress)
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })
@@ -186,9 +186,9 @@ export default {
           link.click()
         })
         .catch((error) => {
-          notification['error']({
+          notification.error({
             message: `${error}`,
-            duration: 4
+            duration: 5
           })
           console.log(error)
         })

--- a/flint.ui/src/views/gcbm/GCBMRun.vue
+++ b/flint.ui/src/views/gcbm/GCBMRun.vue
@@ -95,8 +95,8 @@ import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import Toggle from '@/components/Slider/Toggle.vue'
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
-import { PlayCircleOutlined, QuestionCircleOutlined, DownloadOutlined } from '@ant-design/icons-vue'
+import { PlayCircleOutlined, QuestionCircleOutlined, DownloadOutlined  } from '@ant-design/icons-vue'
+import { notification } from 'ant-design-vue'
 
 export default {
   name: 'DashboardPage',
@@ -119,16 +119,21 @@ export default {
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
-      const toast = useToast()
 
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/dynamic`, bodyFormData)
         .then((response) => {
-          toast.success(`${response.data.status}`, { timeout: 5000 })
+          notification['success']({
+            message: response.data.status,
+            duration: 2
+          })
           console.log(response)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     },
@@ -138,18 +143,23 @@ export default {
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
-      const toast = useToast()
 
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/status`, bodyFormData)
         .then((response) => {
-          toast.info(`${response.data.finished}`, { timeout: 5000 })
+          notification['info']({
+            message: `${response.data.finished}`,
+            duration: 2
+          })
           this.$store.commit('setSimulationProgressState', response.data.finished)
           console.log(response)
           console.log(this.$store.state.gcbm.SimulationProgress)
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     },
@@ -159,7 +169,6 @@ export default {
       bodyFormData.append('title', this.$store.state.gcbm.DropdownSelectedSim)
       console.log(this.$store.state.gcbm.DropdownSelectedSim)
       console.log([...bodyFormData])
-      const toast = useToast()
 
       axios
         .post(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/download`, bodyFormData, {
@@ -177,7 +186,10 @@ export default {
           link.click()
         })
         .catch((error) => {
-          toast.error(`${error}`, { timeout: 2000 })
+          notification['error']({
+            message: `${error}`,
+            duration: 4
+          })
           console.log(error)
         })
     }

--- a/flint.ui/src/views/gcbm/GCBMUpload.vue
+++ b/flint.ui/src/views/gcbm/GCBMUpload.vue
@@ -114,9 +114,9 @@ export default {
       axios.get(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/list`).then((response) => {
         this.simulation_list = response.data.data
         console.log(this.simulation_list)
-        notification['info']({
+        notification.info({
           message: `Ongoing simulations - ${response.data.data}`,
-          duration: 4
+          duration: 5
         })
         console.log(response.data.data)
         console.log(this.simulation_list)

--- a/flint.ui/src/views/gcbm/GCBMUpload.vue
+++ b/flint.ui/src/views/gcbm/GCBMUpload.vue
@@ -74,8 +74,8 @@ import StepperGCBM from '@/components/Stepper/StepperGCBM.vue'
 import FileUpload from '@/components/FileUpload/FileUpload.vue'
 import StepperStatic from '@/components/Stepper/StepperStatic.vue'
 import axios from 'axios'
-import { useToast } from 'vue-toastification'
 import { FileOutlined } from '@ant-design/icons-vue'
+import { notification } from 'ant-design-vue'
 
 export default {
   name: 'DashboardPage',
@@ -111,13 +111,12 @@ export default {
       return this.$store.state.gcbm.DropdownSelectedSim
     },
     getSimulations: function () {
-      const toast = useToast()
-
       axios.get(`${process.env.VUE_APP_REST_API_GCBM}/gcbm/list`).then((response) => {
         this.simulation_list = response.data.data
         console.log(this.simulation_list)
-        toast.info(`Ongoing simulations - ${response.data.data}`, {
-          timeout: 5000
+        notification['info']({
+          message: `Ongoing simulations - ${response.data.data}`,
+          duration: 4
         })
         console.log(response.data.data)
         console.log(this.simulation_list)

--- a/flint.ui/yarn.lock
+++ b/flint.ui/yarn.lock
@@ -14717,11 +14717,6 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue-toastification@^2.0.0-rc.5:
-  version "2.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz#92798604d806ae473cfb76ed776fae294280f8f8"
-  integrity sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==
-
 vue-types@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/vue-types/-/vue-types-3.0.2.tgz#ec16e05d412c038262fc1efa4ceb9647e7fb601d"


### PR DESCRIPTION
## Description
Fixes #314.

The first commit replaces `Toast` invocations with Ant Design `Notifications`. The notification styles and duration are almost exact. A new UX oriented change is that `error` and `warning` notifications now last longer (4 seconds typically) than `success` or `info`  notifications (2 seconds typically) since error messages might take more time to read and digest.

The second commit removes `vue-toastification` dependency from `package.json`.


## Testing
- A reliable way is to head over to `/gcbm/upload` to test the info notification.
- The Run/Status/Download buttons on `/gcbm/run` can also be pressed which should display notifications. See below for expected output.


## Additional Context
`/gcbm/upload`
![image](https://user-images.githubusercontent.com/51860725/174470547-94283406-5f4c-4b64-82cb-4f3514894d8c.png)

`/gcbm/run`
![image](https://user-images.githubusercontent.com/51860725/174470561-dc487dcf-c818-45b0-a5d8-1a6318d70341.png)

<!--- Thanks for opening this pull request! --->
