### PR TITLE
feat: A check to detect if pool values are unchanged

### DIFF
--- a/flint.ui/src/store/modules/point.js
+++ b/flint.ui/src/store/modules/point.js
@@ -18,7 +18,7 @@ export default {
           allow_zero_result_transfers: false
         }
       },
-      Pools: [{ 'Pool 1': 100.0 }, { 'Pool 2': 100.0 }, { 'Pool 3': 100.0 }],
+      Pools: [{ 'Pool 1': null }, { 'Pool 2': null }, { 'Pool 3': null }],
       Variables: [
         {
           localDomainId: 1
@@ -145,10 +145,15 @@ export default {
     point_step: [],
     point_stepDate: [],
     point_stepLenInYears: [],
-    flag: 0 //Thiis is to check if whole Run works.
+    flag: 0, //Thiis is to check if whole Run works.
+    firstRun: true
   },
 
   mutations: {
+    setRunStatus(state, value) {
+      state.firstRun = value
+    },
+
     setNew_point_startDate(state, newValue) {
       this.state.point.config.LocalDomain.start_date = newValue
       console.log(this.state.point.config.LocalDomain.start_date)


### PR DESCRIPTION
## Description
Fixes #349.

This PR:
- Adds a check to detect if pool values are unchanged before running a simulation.
- Adds a little feature to toggle the table when `Point Output Table` button is clicked.

## Testing
Go over to `/flint/configurations/point`. Then, there's really four essential checks:
1. Check if you can run the simulation successfully for the very first time, using an arbitrary input.
2. Check if you can run the simulation a second time, with an arbitrary input.
3. Check if you can can run the simulation with the **same values** as in Step 2. This should pop up a modal. If you click OK, it should dispatch the run.
4. Check if you can run the simulation with arbitrary inputs, again. This should fly without any warnings.

These checks simulate some scenarios that could happen when a user runs the simulation.


## Additional Context
Refer to issue #349.

![image](https://user-images.githubusercontent.com/51860725/183255713-b2f69bf0-c03f-4c8e-a8b6-f4834a197b52.png)



<!--- Thanks for opening this pull request! --->
