### PR TITLE
Fix: Crash while displaying point simulation result

### DIFF
--- a/flint.ui/src/views/flint/ConfigurationsPoint.vue
+++ b/flint.ui/src/views/flint/ConfigurationsPoint.vue
@@ -126,7 +126,7 @@ import PointOuterTable from './PointOuterTable.vue'
 
 import { ref, onMounted, getCurrentInstance, createVNode } from 'vue'
 import { useStore } from 'vuex'
-import { Modal } from 'ant-design-vue'
+import { Modal, notification } from 'ant-design-vue'
 import { ExclamationCircleOutlined } from '@ant-design/icons-vue'
 
 export default {
@@ -241,7 +241,7 @@ export default {
         pool_3: parseInt(pool3.value.pool_value)
       }
 
-      if (store.state.point.firstRun) {
+      if (store.state.point.firstRun === true) {
         // Then return early. This also makes sure that user doesn't get
         // `Modal.confirm` prompt if it's the first time.
         store.commit('setRunStatus', false)
@@ -280,6 +280,18 @@ export default {
     }
 
     function showPointOutputTable() {
+      let firstRun = store.state.point.firstRun
+
+      if (firstRun === true) {
+        notification.error({
+          message: 'Simulation produced no result',
+          description: 'Did you forget to run the simulation first?',
+          duration: 5
+        })
+
+        return
+      }
+
       showTable.value = !showTable.value
     }
 


### PR DESCRIPTION
## Description
Fixes #353.

Fixes a bug where the page would crash ungracefully if `Point Output Table` button was clicked before running the simulation. Log is in the bug report. 

To fix this - we check if the simulation has been ran before, using the `firstRun` state variable. If not, we display an error notification and return early.

## Testing
Head over to `/flint/configurations/point` and click on `Point Output Table` **without** running the simulation first. This should pop up an error notification.

## Additional Context
![image](https://user-images.githubusercontent.com/51860725/188273058-a4ed3563-9779-4d9a-84f4-5ca46e659974.png)


<!--- Thanks for opening this pull request! --->
