### PR TITLE
Replace range sliders of FLINT.UI with UI-library's slider

### DIFF
--- a/flint.ui/src/components/Slider/Slider.vue
+++ b/flint.ui/src/components/Slider/Slider.vue
@@ -44,19 +44,29 @@ export default {
 :deep(.ant-slider:hover .ant-slider-rail) {
   background-color: theme('colors.earth');
 }
+:deep(.ant-slider:hover .ant-slider-handle) {
+  border-color: theme('colors.earth');
+}
+
 :deep(.ant-slider-track) {
-  height: 2px;
+  height: 5px;
   background-color: theme('colors.earth');
+  border-radius: 5px;
 }
 :deep(.ant-slider-rail) {
-  height: 2px;
-  background-color: theme('colors.earth');
+  height: 5px;
+  background-color: gray;
+  border-radius: 5px;
 }
 :deep(.ant-slider-handle) {
-  background-color: theme('colors.earth');
+  background-color: rgb(82, 77, 77);
   border: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -6px;
+  width: 24px;
+  height: 24px;
+  margin-top: -10px;
+  border: 3px;
+  border-style: solid;
+  border-color: white;
+  box-shadow: 2px 2px 5px #aaaaaa;
 }
 </style>

--- a/flint.ui/src/components/Slider/Slider.vue
+++ b/flint.ui/src/components/Slider/Slider.vue
@@ -1,16 +1,27 @@
 <template>
-  <div>
-    <a-slider v-model:value="inputVal" v-bind="$attrs" />
+  <div :style="styles()">
+    <SliderComponent
+      classname="primary"
+      PrimaryColor="#2E382B"
+      OuterWidth="356px"
+      OuterHeight="7px"
+      InnerWidth="16px"
+      InnerHeight="16px"
+      minimum="0"
+      maximum="100"
+      value="22"
+      @clicked="getvalue"
+    />
   </div>
 </template>
 
 <script>
-import { Slider } from 'ant-design-vue'
+import { SliderComponent } from '@moja-global/mojaglobal-ui'
 import { ref, computed } from 'vue'
 
 export default {
   components: {
-    'a-slider': Slider
+    SliderComponent
   },
   emits: ['changeVal'],
   props: {


### PR DESCRIPTION
## Description

This PR fixes #386 

This PR fixes the issue that was raised on 16th sept, Changes has been made to the Slider.vue file. 

Previously:
![Screenshot from 2023-01-16 19-32-51](https://user-images.githubusercontent.com/77936821/212696161-b9620cc8-6e09-4cfa-858f-ba0a4cbab3bf.png)


Now:
![Screenshot from 2023-01-16 19-21-30](https://user-images.githubusercontent.com/77936821/212695909-6975f0a1-169c-43b5-b0e0-ea05ce8275d8.png)


Kindly merge this pr, if there's any changes requested then I would be happy to make them 