### PR TITLE
Fixes RothC page crashes if table is displayed before simulation finishes

### DIFF
--- a/flint.ui/src/store/modules/rothc.js
+++ b/flint.ui/src/store/modules/rothc.js
@@ -241,8 +241,14 @@ export default {
     RothC_stepLenInYears: [],
     initialValues: [],
     plantCM: [],
-    atmosphere: []
+    atmosphere: [],
+    firstRun: true
   },
+
+  mutations: { 
+    setRunStatus(state, value) { 
+      state.firstRun = value 
+    },
 
   mutations: {
     setNew_rothc_startDate(state, newValue) {

--- a/flint.ui/src/store/modules/rothc.js
+++ b/flint.ui/src/store/modules/rothc.js
@@ -245,12 +245,10 @@ export default {
     firstRun: true
   },
 
-  mutations: { 
-    setRunStatus(state, value) { 
-      state.firstRun = value 
-    },
-
   mutations: {
+    setRunStatus(state, value) { 
+        state.firstRun = value 
+    },
     setNew_rothc_startDate(state, newValue) {
       this.state.rothc.config.LocalDomain.start_date = newValue
       console.log(this.state.rothc.config.LocalDomain.start_date)

--- a/flint.ui/src/store/modules/rothc.js
+++ b/flint.ui/src/store/modules/rothc.js
@@ -246,8 +246,8 @@ export default {
   },
 
   mutations: {
-    setRunStatus(state, value) { 
-        state.firstRun = value 
+    setRunStatus(state, value) {
+      state.firstRun = value
     },
     setNew_rothc_startDate(state, newValue) {
       this.state.rothc.config.LocalDomain.start_date = newValue

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -154,7 +154,7 @@ export default {
       }
     })
 
-    if (store.state.point.firstRun === true) {
+    if (store.state.rothc.firstRun === true) {
       // Then return early. This also makes sure that user doesn't get
       // `Modal.confirm` prompt if it's the first time.
       store.commit('setRunStatus', false)
@@ -168,7 +168,7 @@ export default {
     }
 
     function showRothCOutputContainer() {
-      let firstRun = store.state.point.firstRun
+      let firstRun = store.state.rothc.firstRun
       if (firstRun === true) {
         notification.error({
           message: 'Simulation produced no result',

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -91,7 +91,7 @@ import RothCRainfallVue from '@/components/ConfigurationsRothC/RothCRainfall.vue
 
 import { ref } from 'vue'
 import { markRaw } from 'vue'
-import { RightOutlined } from '@ant-design/icons-vue'
+import { RightOutlined, notification } from '@ant-design/icons-vue'
 import { useStore } from 'vuex'
 import { AccordionComponent } from '@moja-global/mojaglobal-ui'
 import { AccordionItem } from '@moja-global/mojaglobal-ui'
@@ -109,6 +109,7 @@ export default {
     ToastComponent
   },
 
+  
   setup() {
     const showTable = ref(false)
     const clickedRun = ref(false)
@@ -153,6 +154,12 @@ export default {
       }
     })
 
+    if (store.state.point.firstRun === true) {
+      // Then return early. This also makes sure that user doesn't get
+      // `Modal.confirm` prompt if it's the first time.
+      store.commit('setRunStatus', false)
+    }
+
     function apiRoute_rothc() {
       // sending the new rothc config
       console.log('ROTHC route invoked with new configs')
@@ -161,6 +168,15 @@ export default {
     }
 
     function showRothCOutputContainer() {
+      let firstRun = store.state.point.firstRun
+      if (firstRun === true) {
+        notification.error({
+          message: 'Simulation produced no result',
+          description: 'Did you forget to run the simulation first?',
+          duration: 5
+        })
+        return
+      }
       store.dispatch('parse_RothC_results')
       showTable.value = true
     }

--- a/flint.ui/src/views/flint/ConfigurationsRothC.vue
+++ b/flint.ui/src/views/flint/ConfigurationsRothC.vue
@@ -109,7 +109,6 @@ export default {
     ToastComponent
   },
 
-  
   setup() {
     const showTable = ref(false)
     const clickedRun = ref(false)


### PR DESCRIPTION
## Description
Fixes #387

Fixes a bug where the page would crash ungracefully if the  Run button quickly followed by the Point Output Table button, the whole thing crashes without any warnings or indicators. A log is in the bug report.

To fix this - we check if the simulation has been ran before, using the firstRun state variable. If not, we display an error notification and return early.

## Testing
Head over to  /flint/configurations/rothc and click on Point Output Table without running the simulation first. This should pop up an error notification.


## Additional Context (Please include any Screenshots/gifs if relevant)
![Screenshot from 2023-01-28 16-54-47](https://user-images.githubusercontent.com/81790585/215264118-73b68e14-cd36-4b28-aa87-928cd749655c.png)

